### PR TITLE
Fix: chart-release workflow

### DIFF
--- a/.github/workflows/release-helm-chart.yaml
+++ b/.github/workflows/release-helm-chart.yaml
@@ -1,4 +1,4 @@
-# workflow for releasing helm-chart as OCI images on github every time a tag is created
+# workflow for releasing helm-chart on github every time a tag is created
 name: Create Helm Release
 on:
   push:
@@ -7,11 +7,12 @@ on:
       - 'chart-v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+' #supports rc versions v1.2.3-rc.4
 
 env:
-  CHART_FOLDER: this/charts/project-origin-wallet/
+  CHART_FOLDER: charts/project-origin-wallet
+  HELM_REGISTRY_REPOSITORY: project-origin/helm-registry
 
 jobs:
-  build:
-    name: Build
+  release:
+    name: Release helm chart
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
@@ -20,20 +21,20 @@ jobs:
 
       - uses: actions/checkout@v3
         with:
-          repository: project-origin/helm-registry
+          repository: ${{ env.HELM_REGISTRY_REPOSITORY }}
           path: helm-registry
           ssh-key: ${{ secrets.HELM_REGISTRY_TOKEN }}
 
       - name: Get chart name and version
         id: variables
         run: |
-          echo "name=$(yq .name < ${{ env.CHART_FOLDER }}/Chart.yaml)" >> $GITHUB_OUTPUT
+          echo "name=$(yq .name < this/${{ env.CHART_FOLDER }}/Chart.yaml)" >> $GITHUB_OUTPUT
           echo "version=${GITHUB_REF#refs/*/chart-v}" >> $GITHUB_OUTPUT
 
       - name: Package and generate index
         run: |
-          helm package ${{ env.CHART_FOLDER }} --version ${{ steps.variables.outputs.version }} --destination helm-releases
-          helm repo index helm-releases --merge helm-registry/index.yaml --url https://github.com/project-origin/registry/releases/download/chart-v${{ steps.variables.outputs.version }}/
+          helm package this/${{ env.CHART_FOLDER }} --version ${{ steps.variables.outputs.version }} --destination helm-releases
+          helm repo index helm-releases --merge helm-registry/index.yaml --url https://github.com/${{ github.repository }}/releases/download/chart-v${{ steps.variables.outputs.version }}/
           cp helm-releases/index.yaml helm-registry/index.yaml
 
       - name: Create Release


### PR DESCRIPTION
The workflow still had a path from the project-origin/registry repository, this has been fixed to ${{ github.repository }}.