### PR TITLE
Pin devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,6 +14,9 @@
         },
         "ghcr.io/devcontainers/features/rust:1": {
             "version": "latest"
+        },
+        "ghcr.io/devcontainers/features/dotnet": {
+            "version": "7.0.203"
         }
     },
     // Use 'forwardPorts' to make a list of ports inside the container available locally.


### PR DESCRIPTION
Dockerfile build failed locally when downloading Helm. But that should be unrelated to pinning of the dotnet SDK version