### PR TITLE
Fixed VerifySlice now verifies position and key matches

### DIFF
--- a/src/ProjectOrigin.WalletSystem.IntegrationTests/VerifySlicesWorkerTests.cs
+++ b/src/ProjectOrigin.WalletSystem.IntegrationTests/VerifySlicesWorkerTests.cs
@@ -30,11 +30,13 @@ public class VerifySlicesWorkerTests : WalletSystemTestsBase, IClassFixture<Regi
         var owner = _fixture.Create<string>();
         var depositEndpoint = await CreateWalletDepositEndpoint(owner);
         var commitment = new SecretCommitmentInfo(150);
+        var position = 1;
+        var publicKey = depositEndpoint.PublicKey.Derive(position).GetPublicKey();
 
-        var issuedEvent = await _registryFixture.IssueCertificate(Electricity.V1.GranularCertificateType.Production, commitment, depositEndpoint.PublicKey.GetPublicKey());
+        var issuedEvent = await _registryFixture.IssueCertificate(Electricity.V1.GranularCertificateType.Production, commitment, publicKey);
         var certId = Guid.Parse(issuedEvent.CertificateId.StreamId.Value);
 
-        var receivedSlice = await CreateReceivedSlice(depositEndpoint, issuedEvent.CertificateId.Registry, certId, commitment.Message, commitment.BlindingValue.ToArray());
+        var receivedSlice = await CreateReceivedSlice(depositEndpoint, position, issuedEvent.CertificateId.Registry, certId, commitment.Message, commitment.BlindingValue.ToArray());
 
         await using (var connection = new NpgsqlConnection(_dbFixture.ConnectionString))
         {
@@ -54,11 +56,12 @@ public class VerifySlicesWorkerTests : WalletSystemTestsBase, IClassFixture<Regi
         var owner = _fixture.Create<string>();
         var depositEndpoint = await CreateWalletDepositEndpoint(owner);
         var commitment = new SecretCommitmentInfo(150);
+        var position = 1;
 
         var certId = Guid.NewGuid();
         var registryName = _registryFixture.Name;
 
-        var receivedSlice = await CreateReceivedSlice(depositEndpoint, registryName, certId, commitment.Message, commitment.BlindingValue.ToArray());
+        await CreateReceivedSlice(depositEndpoint, position, registryName, certId, commitment.Message, commitment.BlindingValue.ToArray());
 
         await using (var connection = new NpgsqlConnection(_dbFixture.ConnectionString))
         {
@@ -76,11 +79,37 @@ public class VerifySlicesWorkerTests : WalletSystemTestsBase, IClassFixture<Regi
         var owner = _fixture.Create<string>();
         var depositEndpoint = await CreateWalletDepositEndpoint(owner);
         var commitment = new SecretCommitmentInfo(150);
+        var position = 1;
 
         var certId = Guid.NewGuid();
         var registryName = _fixture.Create<string>();
 
-        var receivedSlice = await CreateReceivedSlice(depositEndpoint, registryName, certId, commitment.Message, commitment.BlindingValue.ToArray());
+        await CreateReceivedSlice(depositEndpoint, position, registryName, certId, commitment.Message, commitment.BlindingValue.ToArray());
+
+        await using (var connection = new NpgsqlConnection(_dbFixture.ConnectionString))
+        {
+            var rSlice = await connection.RepeatedlyQueryUntilNull<ReceivedSlice>("SELECT * FROM ReceivedSlices WHERE certificateId = @id", new { id = certId });
+            rSlice.Should().BeNull();
+
+            var cert = await connection.QueryAsync<Certificate>("SELECT * FROM Certificates WHERE id = @id", new { id = certId });
+            cert.Should().BeEmpty();
+        }
+    }
+
+    [Fact]
+    public async void WhenPositionDoesNotMatchKey_ExpectReceivedSliceDeleted()
+    {
+        var owner = _fixture.Create<string>();
+        var depositEndpoint = await CreateWalletDepositEndpoint(owner);
+        var commitment = new SecretCommitmentInfo(150);
+        var position = 1;
+
+        var publicKey = depositEndpoint.PublicKey.Derive(position + 1).GetPublicKey();
+
+        var issuedEvent = await _registryFixture.IssueCertificate(Electricity.V1.GranularCertificateType.Production, commitment, publicKey);
+        var certId = Guid.Parse(issuedEvent.CertificateId.StreamId.Value);
+
+        await CreateReceivedSlice(depositEndpoint, position, issuedEvent.CertificateId.Registry, certId, commitment.Message, commitment.BlindingValue.ToArray());
 
         await using (var connection = new NpgsqlConnection(_dbFixture.ConnectionString))
         {

--- a/src/ProjectOrigin.WalletSystem.IntegrationTests/VerifySlicesWorkerTests.cs
+++ b/src/ProjectOrigin.WalletSystem.IntegrationTests/VerifySlicesWorkerTests.cs
@@ -104,7 +104,8 @@ public class VerifySlicesWorkerTests : WalletSystemTestsBase, IClassFixture<Regi
         var commitment = new SecretCommitmentInfo(150);
         var position = 1;
 
-        var publicKey = depositEndpoint.PublicKey.Derive(position + 1).GetPublicKey();
+        var wrongPosition = position + 1;
+        var publicKey = depositEndpoint.PublicKey.Derive(wrongPosition).GetPublicKey();
 
         var issuedEvent = await _registryFixture.IssueCertificate(Electricity.V1.GranularCertificateType.Production, commitment, publicKey);
         var certId = Guid.Parse(issuedEvent.CertificateId.StreamId.Value);

--- a/src/ProjectOrigin.WalletSystem.IntegrationTests/WalletSystemTestsBase.cs
+++ b/src/ProjectOrigin.WalletSystem.IntegrationTests/WalletSystemTestsBase.cs
@@ -79,13 +79,19 @@ public abstract class WalletSystemTestsBase : IClassFixture<GrpcTestFixture<Star
         }
     }
 
-    protected async Task<ReceivedSlice> CreateReceivedSlice(DepositEndpoint depositEndpoint, string registryName, Guid certificateId, long quantity, byte[] randomR)
+    protected async Task<ReceivedSlice> CreateReceivedSlice(DepositEndpoint depositEndpoint, int position, string registryName, Guid certificateId, long quantity, byte[] randomR)
     {
         using (var connection = new NpgsqlConnection(_dbFixture.ConnectionString))
         {
             var certificateRepository = new CertificateRepository(connection);
-            var receivedSlice = new ReceivedSlice(Guid.NewGuid(), depositEndpoint.Id, depositEndpoint.WalletPosition!.Value,
-                registryName, certificateId, quantity, randomR);
+            var receivedSlice = new ReceivedSlice(
+                Guid.NewGuid(),
+                depositEndpoint.Id,
+                position,
+                registryName,
+                certificateId,
+                quantity,
+                randomR);
 
             await certificateRepository.InsertReceivedSlice(receivedSlice);
             return receivedSlice;

--- a/src/ProjectOrigin.WalletSystem.Server/BackgroundJobs/VerifySlicesWorker.cs
+++ b/src/ProjectOrigin.WalletSystem.Server/BackgroundJobs/VerifySlicesWorker.cs
@@ -83,7 +83,7 @@ public class VerifySlicesWorker : BackgroundService
                 var depositEndpoint = await unitOfWork.WalletRepository.GetDepositEndpoint(receivedSlice.DepositEndpointId);
                 var positionPublicKey = depositEndpoint.PublicKey.Derive(receivedSlice.DepositEndpointPosition).GetPublicKey();
 
-                if (!foundSlice.Owner.ToModel().Equals(positionPublicKey))
+                if (!foundSlice.Owner.ImportKey().Equals(positionPublicKey))
                 {
                     _logger.LogError($"Not correct publicKey on {receivedSlice.CertificateId}, Deleting received slice.");
                     await unitOfWork.CertificateRepository.RemoveReceivedSlice(receivedSlice);

--- a/src/ProjectOrigin.WalletSystem.Server/BackgroundJobs/VerifySlicesWorker.cs
+++ b/src/ProjectOrigin.WalletSystem.Server/BackgroundJobs/VerifySlicesWorker.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using ProjectOrigin.WalletSystem.Server.Database;
+using ProjectOrigin.WalletSystem.Server.Extensions;
 using ProjectOrigin.WalletSystem.Server.Models;
 using ProjectOrigin.WalletSystem.Server.Projections;
 using ProjectOrigin.WalletSystem.Server.Services;
@@ -74,6 +75,17 @@ public class VerifySlicesWorker : BackgroundService
                 if (foundSlice is null)
                 {
                     _logger.LogWarning($"Slice with id {sliceId} not found in certificate {receivedSlice.CertificateId}. Deleting received slice.");
+                    await unitOfWork.CertificateRepository.RemoveReceivedSlice(receivedSlice);
+                    unitOfWork.Commit();
+                    return;
+                }
+
+                var depositEndpoint = await unitOfWork.WalletRepository.GetDepositEndpoint(receivedSlice.DepositEndpointId);
+                var positionPublicKey = depositEndpoint.PublicKey.Derive(receivedSlice.DepositEndpointPosition).GetPublicKey();
+
+                if (!foundSlice.Owner.ToModel().Equals(positionPublicKey))
+                {
+                    _logger.LogError($"Not correct publicKey on {receivedSlice.CertificateId}, Deleting received slice.");
                     await unitOfWork.CertificateRepository.RemoveReceivedSlice(receivedSlice);
                     unitOfWork.Commit();
                     return;

--- a/src/ProjectOrigin.WalletSystem.Server/Extensions/PublicKeyExtensions.cs
+++ b/src/ProjectOrigin.WalletSystem.Server/Extensions/PublicKeyExtensions.cs
@@ -1,0 +1,24 @@
+using System;
+using ProjectOrigin.Electricity.V1;
+using ProjectOrigin.HierarchicalDeterministicKeys.Implementations;
+using ProjectOrigin.HierarchicalDeterministicKeys.Interfaces;
+
+namespace ProjectOrigin.WalletSystem.Server.Extensions;
+
+public static class PublicKeyExtensions
+{
+    public static IPublicKey ToModel(this PublicKey key)
+    {
+        switch (key.Type)
+        {
+            case KeyType.Secp256K1:
+                return (new Secp256k1Algorithm()).ImportPublicKey(key.Content.Span);
+
+            case KeyType.Ed25519:
+                return (new Ed25519Algorithm()).ImportPublicKey(key.Content.Span);
+
+            default:
+                throw new NotSupportedException();
+        }
+    }
+}

--- a/src/ProjectOrigin.WalletSystem.Server/Extensions/PublicKeyExtensions.cs
+++ b/src/ProjectOrigin.WalletSystem.Server/Extensions/PublicKeyExtensions.cs
@@ -1,5 +1,4 @@
 using System;
-using ProjectOrigin.Electricity.V1;
 using ProjectOrigin.HierarchicalDeterministicKeys.Implementations;
 using ProjectOrigin.HierarchicalDeterministicKeys.Interfaces;
 
@@ -7,15 +6,15 @@ namespace ProjectOrigin.WalletSystem.Server.Extensions;
 
 public static class PublicKeyExtensions
 {
-    public static IPublicKey ToModel(this PublicKey key)
+    public static IPublicKey ImportKey(this Electricity.V1.PublicKey key)
     {
         switch (key.Type)
         {
-            case KeyType.Secp256K1:
-                return (new Secp256k1Algorithm()).ImportPublicKey(key.Content.Span);
+            case Electricity.V1.KeyType.Secp256K1:
+                return new Secp256k1Algorithm().ImportPublicKey(key.Content.Span);
 
-            case KeyType.Ed25519:
-                return (new Ed25519Algorithm()).ImportPublicKey(key.Content.Span);
+            case Electricity.V1.KeyType.Ed25519:
+                return new Ed25519Algorithm().ImportPublicKey(key.Content.Span);
 
             default:
                 throw new NotSupportedException();


### PR DESCRIPTION
The slice verifier now verifies that the received slice publickey matches the key derived from the position.