### PR TITLE
Added MessageBroker configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,13 +62,4 @@ unit-test:
 verify-chart:
 	@kind version >/dev/null 2>&1 || { echo >&2 "kind not installed! kind is required to use recipe, please install or use devcontainer"; exit 1;}
 	@helm version >/dev/null 2>&1 || { echo >&2 "helm not installed! helm is required to use recipe, please install or use devcontainer"; exit 1;}
-
-	kind delete cluster -n helm-test
-	kind create cluster -n helm-test
-	helm install cnpg-operator cloudnative-pg --repo https://cloudnative-pg.io/charts --version 0.18.0 --namespace cnpg --create-namespace --wait
-
-	docker build -f src/ProjectOrigin.WalletSystem.Server/Dockerfile -t ghcr.io/project-origin/wallet-server:test src/
-	kind load -n helm-test docker-image ghcr.io/project-origin/wallet-server:test
-	helm install wallet charts/project-origin-wallet --set image.tag=test,wallet.externalUrl=http://wallet.example:80 --namespace wallet --create-namespace --wait
-
-	kind delete cluster -n helm-test
+	charts/project-origin-wallet/run_kind_test.sh

--- a/charts/project-origin-wallet/run_kind_test.sh
+++ b/charts/project-origin-wallet/run_kind_test.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# This script is used to test the wallet chart using kind.
+# It installs the chart and validates it starts up correctly.
+
+# Define kind cluster name
+cluster_name=wallet-test
+
+# Ensures script fails if something goes wrong.
+set -eo pipefail
+
+# cleanup - delete temp_folder and cluster
+trap 'rm -fr $temp_folder; kind delete cluster -n ${cluster_name} >/dev/null 2>&1' 0
+
+# define variables
+temp_folder=$(mktemp -d)
+values_filename=${temp_folder}/values.yaml
+
+# create kind cluster
+kind delete cluster -n ${cluster_name}
+kind create cluster -n ${cluster_name}
+
+# install rabbitmq-operator
+kubectl apply -f "https://github.com/rabbitmq/cluster-operator/releases/download/v2.5.0/cluster-operator.yml"
+
+# install cnpg-operator
+helm install cnpg-operator cloudnative-pg --repo https://cloudnative-pg.io/charts --version 0.18.0 --namespace cnpg --create-namespace --wait
+
+# build docker image
+docker build -f src/ProjectOrigin.WalletSystem.Server/Dockerfile -t ghcr.io/project-origin/wallet-server:test src/
+
+# load docker image into cluster
+kind load -n ${cluster_name} docker-image ghcr.io/project-origin/wallet-server:test
+
+# generate values.yaml file
+cat << EOF > "${values_filename}"
+image:
+  tag: test
+
+wallet:
+  externalUrl: http://wallet.example:80
+
+messageBroker:
+  type: rabbitmqOperator
+EOF
+
+# install wallet chart
+helm install wallet charts/project-origin-wallet --values ${values_filename} --namespace wallet --create-namespace --wait
+
+echo "Test completed"

--- a/charts/project-origin-wallet/templates/deployment-wallet.yaml
+++ b/charts/project-origin-wallet/templates/deployment-wallet.yaml
@@ -32,6 +32,46 @@ spec:
           env:
             - name: ServiceOptions__EndpointAddress
               value: {{ required "A valid externalUrl is required!"  .Values.wallet.externalUrl }}
+            {{- if eq .Values.messageBroker.type "inMemory" }}
+            - name: MessageBroker__Type
+              value: InMemory
+            {{- else if eq .Values.messageBroker.type "rabbitmq" }}
+            - name: MessageBroker__Type
+              value: RabbitMq
+            - name: MessageBroker__RabbitMQ__Host
+              value: {{ required "A valid messageBroker rabbitmq host is required!" .Values.messageBroker.rabbitmq.host }}
+            - name: MessageBroker__RabbitMQ__Port
+              value: {{ required "A valid messageBroker rabbitmq port is required!" .Values.messageBroker.rabbitmq.port }}
+            - name: MessageBroker__RabbitMQ__Username
+              value: {{ required "A valid messageBroker rabbitmq username is required!" .Values.messageBroker.rabbitmq.username }}
+            - name: MessageBroker__RabbitMQ__Password
+              value: {{ required "A valid messageBroker rabbitmq password is required!" .Values.messageBroker.rabbitmq.password }}
+            {{- else if eq .Values.messageBroker.type "rabbitmqOperator" }}
+            - name: MessageBroker__Type
+              value: RabbitMq
+            - name: MessageBroker__RabbitMQ__Host
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-rabbitmq-default-user
+                  key: host
+            - name: MessageBroker__RabbitMQ__Port
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-rabbitmq-default-user
+                  key: port
+            - name: MessageBroker__RabbitMQ__Username
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-rabbitmq-default-user
+                  key: username
+            - name: MessageBroker__RabbitMQ__Password
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-rabbitmq-default-user
+                  key: password
+            {{- else}}
+            {{- fail "messageBroker type must be one of (inMemory | rabbitmq | rabbitmqOperator)" }}
+            {{- end }}
             {{- range .Values.registries }}
             - name: RegistryUrls__{{ .name }}
               value: {{ .address }}

--- a/charts/project-origin-wallet/templates/rabbitmq.yaml
+++ b/charts/project-origin-wallet/templates/rabbitmq.yaml
@@ -1,0 +1,7 @@
+{{- if eq .Values.messageBroker.type "rabbitmqOperator" }}
+apiVersion: rabbitmq.com/v1beta1
+kind: RabbitmqCluster
+metadata:
+  name: {{ .Release.Name }}-rabbitmq
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/project-origin-wallet/values.yaml
+++ b/charts/project-origin-wallet/values.yaml
@@ -20,7 +20,7 @@ messageBroker:
   # type defines the type of message broker to use, allowed values are (inMemory | rabbitmq | rabbitmqOperator)
   type:
 
-  # rabbitmq defines the rabbitmq configuration for the message broker if type is rabbitmq, with rabbitmqOperator this is ignored
+  # rabbitmq defines the rabbitmq configuration for the message broker if type is rabbitmq, with rabbitmqOperator or inMemory this is ignored
   rabbitmq:
     # host defines the host of the rabbitmq server in url format 'http://localhost:15672/'
     host:

--- a/charts/project-origin-wallet/values.yaml
+++ b/charts/project-origin-wallet/values.yaml
@@ -16,6 +16,21 @@ service:
   # nodePort is the port to expose the service on if type is NodePort
   nodePort:
 
+messageBroker:
+  # type defines the type of message broker to use, allowed values are (inMemory | rabbitmq | rabbitmqOperator)
+  type:
+
+  # rabbitmq defines the rabbitmq configuration for the message broker if type is rabbitmq, with rabbitmqOperator this is ignored
+  rabbitmq:
+    # host defines the host of the rabbitmq server in url format 'http://localhost:15672/'
+    host:
+    # port defines the port of the rabbitmq server, defaults to 5672
+    port: 5672
+    # username defines the username to use to connect to the rabbitmq server
+    username:
+    # password defines the password to use to connect to the rabbitmq server
+    password:
+
 # wallet defines the service configuration for the wallet server
 wallet:
 

--- a/src/ProjectOrigin.WalletSystem.IntegrationTests/GrpcTests.cs
+++ b/src/ProjectOrigin.WalletSystem.IntegrationTests/GrpcTests.cs
@@ -12,10 +12,19 @@ using Xunit.Abstractions;
 
 namespace ProjectOrigin.WalletSystem.IntegrationTests;
 
-public class GrpcTests : WalletSystemTestsBase
+public class GrpcTests : WalletSystemTestsBase, IClassFixture<InMemoryFixture>
 {
-    public GrpcTests(GrpcTestFixture<Startup> grpcFixture, PostgresDatabaseFixture dbFixture, ITestOutputHelper outputHelper)
-        : base(grpcFixture, dbFixture, outputHelper, null)
+    public GrpcTests(
+        GrpcTestFixture<Startup> grpcFixture,
+        PostgresDatabaseFixture dbFixture,
+        InMemoryFixture memoryFixture,
+        ITestOutputHelper outputHelper)
+        : base(
+            grpcFixture,
+            dbFixture,
+            memoryFixture,
+            outputHelper,
+            null)
     {
     }
 

--- a/src/ProjectOrigin.WalletSystem.IntegrationTests/MessageBroker/ConfigurationTests.cs
+++ b/src/ProjectOrigin.WalletSystem.IntegrationTests/MessageBroker/ConfigurationTests.cs
@@ -140,7 +140,7 @@ public class ConfigurationTests
     }
 
     [Fact]
-    public void RabbitMqMisconfiguredUrl()
+    public void RabbitMqMisconfiguredHost()
     {
         // Arrange
         var configuration = new ConfigurationBuilder()

--- a/src/ProjectOrigin.WalletSystem.IntegrationTests/MessageBroker/ConfigurationTests.cs
+++ b/src/ProjectOrigin.WalletSystem.IntegrationTests/MessageBroker/ConfigurationTests.cs
@@ -1,0 +1,183 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using AutoFixture;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using ProjectOrigin.WalletSystem.Server.Extensions;
+using ProjectOrigin.WalletSystem.Server.Options;
+using Xunit;
+
+namespace ProjectOrigin.WalletSystem.IntegrationTests.MessageBroker;
+
+public class ConfigurationTests
+{
+    private const string SectionName = "MessageBroker";
+
+    [Fact]
+    public void MissingConfiguration()
+    {
+        // Arrange
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>())
+            .Build();
+
+        // Act
+        Action act = () => configuration.GetSection(SectionName).GetValid<MessageBrokerOptions>();
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void InvalidType()
+    {
+        // Arrange
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [$"{SectionName}:{nameof(MessageBrokerOptions.Type)}"] = "InvalidType",
+            })
+            .Build();
+
+        // Act
+        Action act = () => configuration.GetSection(SectionName).GetValid<MessageBrokerOptions>();
+
+        // Assert
+        act.Should().Throw<ValidationException>();
+    }
+
+    [Fact]
+    public void InMemoryValid()
+    {
+        // Arrange
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [$"{SectionName}:{nameof(MessageBrokerOptions.Type)}"] = MessageBrokerType.InMemory.ToString(),
+            })
+            .Build();
+
+        // Act
+        var options = configuration.GetSection(SectionName).GetValid<MessageBrokerOptions>();
+
+        // Assert
+        options.Should().NotBeNull();
+        options.Type.Should().Be(MessageBrokerType.InMemory);
+        options.RabbitMq.Should().BeNull();
+    }
+
+    [Fact]
+    public void InMemoryWierdCaseValid()
+    {
+        // Arrange
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [$"{SectionName}:{nameof(MessageBrokerOptions.Type)}"] = "iNMeMory",
+            })
+            .Build();
+
+        // Act
+        var options = configuration.GetSection(SectionName).GetValid<MessageBrokerOptions>();
+
+        // Assert
+        options.Should().NotBeNull();
+        options.Type.Should().Be(MessageBrokerType.InMemory);
+        options.RabbitMq.Should().BeNull();
+    }
+
+    [Fact]
+    public void RabbitMqValid()
+    {
+        // Arrange
+        var fixture = new Fixture();
+        var host = "localhost";
+        ushort port = 5672;
+        var username = fixture.Create<string>();
+        var password = fixture.Create<string>();
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [$"{SectionName}:{nameof(MessageBrokerOptions.Type)}"] = MessageBrokerType.RabbitMq.ToString(),
+                [$"{SectionName}:{nameof(MessageBrokerOptions.RabbitMq)}:{nameof(RabbitMqOptions.Host)}"] = host,
+                [$"{SectionName}:{nameof(MessageBrokerOptions.RabbitMq)}:{nameof(RabbitMqOptions.Port)}"] = port.ToString(),
+                [$"{SectionName}:{nameof(MessageBrokerOptions.RabbitMq)}:{nameof(RabbitMqOptions.Username)}"] = username,
+                [$"{SectionName}:{nameof(MessageBrokerOptions.RabbitMq)}:{nameof(RabbitMqOptions.Password)}"] = password,
+            })
+            .Build();
+
+        // Act
+        var options = configuration.GetSection(SectionName).GetValid<MessageBrokerOptions>();
+
+        // Assert
+        options.Should().NotBeNull();
+        options.Type.Should().Be(MessageBrokerType.RabbitMq);
+        options.RabbitMq.Should().NotBeNull();
+        options.RabbitMq!.Host.Should().Be(host);
+        options.RabbitMq!.Port.Should().Be(port);
+        options.RabbitMq!.Username.Should().Be(username);
+        options.RabbitMq!.Password.Should().Be(password);
+    }
+
+    [Fact]
+    public void RabbitMqMissingConfiguration()
+    {
+        // Arrange
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [$"{SectionName}:{nameof(MessageBrokerOptions.Type)}"] = MessageBrokerType.RabbitMq.ToString(),
+            })
+            .Build();
+
+        // Act
+        Action act = () => configuration.GetSection($"{SectionName}").GetValid<MessageBrokerOptions>();
+
+        // Assert
+        act.Should().Throw<ValidationException>();
+    }
+
+    [Fact]
+    public void RabbitMqMisconfiguredUrl()
+    {
+        // Arrange
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [$"{SectionName}:{nameof(MessageBrokerOptions.Type)}"] = MessageBrokerType.RabbitMq.ToString(),
+                [$"{SectionName}:{nameof(MessageBrokerOptions.RabbitMq)}:{nameof(RabbitMqOptions.Host)}"] = "",
+                [$"{SectionName}:{nameof(MessageBrokerOptions.RabbitMq)}:{nameof(RabbitMqOptions.Port)}"] = "5672",
+                [$"{SectionName}:{nameof(MessageBrokerOptions.RabbitMq)}:{nameof(RabbitMqOptions.Username)}"] = "guest",
+                [$"{SectionName}:{nameof(MessageBrokerOptions.RabbitMq)}:{nameof(RabbitMqOptions.Password)}"] = "guest",
+            })
+            .Build();
+
+        // Act
+        Action act = () => configuration.GetSection($"{SectionName}").GetValid<MessageBrokerOptions>();
+
+        // Assert
+        act.Should().Throw<ValidationException>();
+    }
+
+    [Fact]
+    public void RabbitMqMissingFields()
+    {
+        // Arrange
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [$"{SectionName}:{nameof(MessageBrokerOptions.Type)}"] = MessageBrokerType.RabbitMq.ToString(),
+                [$"{SectionName}:{nameof(MessageBrokerOptions.RabbitMq)}:{nameof(RabbitMqOptions.Host)}"] = "localhost",
+                [$"{SectionName}:{nameof(MessageBrokerOptions.RabbitMq)}:{nameof(RabbitMqOptions.Password)}"] = "guest",
+            })
+            .Build();
+
+        // Act
+        Action act = () => configuration.GetSection($"{SectionName}").GetValid<MessageBrokerOptions>();
+
+        // Assert
+        act.Should().Throw<ValidationException>();
+    }
+}

--- a/src/ProjectOrigin.WalletSystem.IntegrationTests/MessageBroker/RabbitMqTests.cs
+++ b/src/ProjectOrigin.WalletSystem.IntegrationTests/MessageBroker/RabbitMqTests.cs
@@ -1,0 +1,29 @@
+using ProjectOrigin.WalletSystem.IntegrationTests.TestClassFixtures;
+using ProjectOrigin.WalletSystem.Server;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace ProjectOrigin.WalletSystem.IntegrationTests.MessageBroker;
+
+public class RabbitMqTests : WalletSystemTestsBase, IClassFixture<RabbitMqFixture>
+{
+    public RabbitMqTests(
+        GrpcTestFixture<Startup> grpcFixture,
+        PostgresDatabaseFixture dbFixture,
+        RabbitMqFixture messageBrokerFixture,
+        ITestOutputHelper outputHelper) : base(
+            grpcFixture,
+            dbFixture,
+            messageBrokerFixture,
+            outputHelper,
+            null)
+    {
+    }
+
+    [Fact]
+    public void VerifyHostStarts()
+    {
+        // More will be added here later
+        Assert.True(true);
+    }
+}

--- a/src/ProjectOrigin.WalletSystem.IntegrationTests/MessageBroker/RabbitMqTests.cs
+++ b/src/ProjectOrigin.WalletSystem.IntegrationTests/MessageBroker/RabbitMqTests.cs
@@ -23,7 +23,7 @@ public class RabbitMqTests : WalletSystemTestsBase, IClassFixture<RabbitMqFixtur
     [Fact]
     public void VerifyHostStarts()
     {
-        // More will be added here later
+        // TODO: write test with test-harness
         Assert.True(true);
     }
 }

--- a/src/ProjectOrigin.WalletSystem.IntegrationTests/MigrationTests.cs
+++ b/src/ProjectOrigin.WalletSystem.IntegrationTests/MigrationTests.cs
@@ -1,5 +1,6 @@
 using Dapper;
 using FluentAssertions;
+using ProjectOrigin.WalletSystem.IntegrationTests.TestClassFixtures;
 using System;
 using System.Threading.Tasks;
 using Xunit;

--- a/src/ProjectOrigin.WalletSystem.IntegrationTests/ProjectOrigin.WalletSystem.IntegrationTests.csproj
+++ b/src/ProjectOrigin.WalletSystem.IntegrationTests/ProjectOrigin.WalletSystem.IntegrationTests.csproj
@@ -12,7 +12,8 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="Testcontainers.PostgreSql" Version="3.4.0" />
+    <PackageReference Include="Testcontainers.PostgreSql" Version="3.5.0" />
+    <PackageReference Include="Testcontainers.RabbitMq" Version="3.5.0" />
     <PackageReference Include="xunit" Version="2.5.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/ProjectOrigin.WalletSystem.IntegrationTests/QueryCertificatesTest.cs
+++ b/src/ProjectOrigin.WalletSystem.IntegrationTests/QueryCertificatesTest.cs
@@ -20,12 +20,21 @@ using ProjectOrigin.HierarchicalDeterministicKeys.Interfaces;
 
 namespace ProjectOrigin.WalletSystem.IntegrationTests
 {
-    public class QueryCertificatesTest : WalletSystemTestsBase
+    public class QueryCertificatesTest : WalletSystemTestsBase, IClassFixture<InMemoryFixture>
     {
         private Fixture _fixture;
 
-        public QueryCertificatesTest(GrpcTestFixture<Startup> grpcFixture, PostgresDatabaseFixture dbFixture, ITestOutputHelper outputHelper)
-            : base(grpcFixture, dbFixture, outputHelper, null)
+        public QueryCertificatesTest(
+            GrpcTestFixture<Startup> grpcFixture,
+            PostgresDatabaseFixture dbFixture,
+            InMemoryFixture inMemoryFixture,
+            ITestOutputHelper outputHelper)
+            : base(
+                  grpcFixture,
+                  dbFixture,
+                  inMemoryFixture,
+                  outputHelper,
+                  null)
         {
             _fixture = new Fixture();
 

--- a/src/ProjectOrigin.WalletSystem.IntegrationTests/ReceiveSliceTests.cs
+++ b/src/ProjectOrigin.WalletSystem.IntegrationTests/ReceiveSliceTests.cs
@@ -13,10 +13,19 @@ using AutoFixture;
 
 namespace ProjectOrigin.WalletSystem.IntegrationTests
 {
-    public class ReceiveSliceTests : WalletSystemTestsBase
+    public class ReceiveSliceTests : WalletSystemTestsBase, IClassFixture<InMemoryFixture>
     {
-        public ReceiveSliceTests(GrpcTestFixture<Startup> grpcFixture, PostgresDatabaseFixture dbFixture, ITestOutputHelper outputHelper)
-            : base(grpcFixture, dbFixture, outputHelper, null)
+        public ReceiveSliceTests(
+            GrpcTestFixture<Startup> grpcFixture,
+            PostgresDatabaseFixture dbFixture,
+            InMemoryFixture inMemoryFixture,
+            ITestOutputHelper outputHelper)
+            : base(
+                  grpcFixture,
+                  dbFixture,
+                  inMemoryFixture,
+                  outputHelper,
+                  null)
         {
         }
 

--- a/src/ProjectOrigin.WalletSystem.IntegrationTests/ReceiverDepositEndpointTests.cs
+++ b/src/ProjectOrigin.WalletSystem.IntegrationTests/ReceiverDepositEndpointTests.cs
@@ -14,12 +14,21 @@ using Xunit.Abstractions;
 
 namespace ProjectOrigin.WalletSystem.IntegrationTests
 {
-    public class ReceiverDepositEndpointTests : WalletSystemTestsBase
+    public class ReceiverDepositEndpointTests : WalletSystemTestsBase, IClassFixture<InMemoryFixture>
     {
         private Fixture _fixture;
 
-        public ReceiverDepositEndpointTests(GrpcTestFixture<Startup> grpcFixture, PostgresDatabaseFixture dbFixture, ITestOutputHelper outputHelper)
-            : base(grpcFixture, dbFixture, outputHelper, null)
+        public ReceiverDepositEndpointTests(
+            GrpcTestFixture<Startup> grpcFixture,
+            PostgresDatabaseFixture dbFixture,
+            InMemoryFixture inMemoryFixture,
+            ITestOutputHelper outputHelper)
+            : base(
+                  grpcFixture,
+                  dbFixture,
+                  inMemoryFixture,
+                  outputHelper,
+                  null)
         {
             _fixture = new Fixture();
         }

--- a/src/ProjectOrigin.WalletSystem.IntegrationTests/Repositories/AbstractRepositoryTests.cs
+++ b/src/ProjectOrigin.WalletSystem.IntegrationTests/Repositories/AbstractRepositoryTests.cs
@@ -12,6 +12,7 @@ using ProjectOrigin.WalletSystem.Server.Extensions;
 using Xunit;
 using ProjectOrigin.HierarchicalDeterministicKeys.Interfaces;
 using ProjectOrigin.HierarchicalDeterministicKeys.Implementations;
+using ProjectOrigin.WalletSystem.IntegrationTests.TestClassFixtures;
 
 namespace ProjectOrigin.WalletSystem.IntegrationTests.Repositories;
 

--- a/src/ProjectOrigin.WalletSystem.IntegrationTests/Repositories/CertificateRepositoryTests.cs
+++ b/src/ProjectOrigin.WalletSystem.IntegrationTests/Repositories/CertificateRepositoryTests.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using ProjectOrigin.WalletSystem.Server.Extensions;
 using Xunit;
+using ProjectOrigin.WalletSystem.IntegrationTests.TestClassFixtures;
 
 namespace ProjectOrigin.WalletSystem.IntegrationTests.Repositories;
 

--- a/src/ProjectOrigin.WalletSystem.IntegrationTests/Repositories/RegistryRepositoryTests.cs
+++ b/src/ProjectOrigin.WalletSystem.IntegrationTests/Repositories/RegistryRepositoryTests.cs
@@ -1,10 +1,8 @@
 using AutoFixture;
-using Dapper;
 using FluentAssertions;
+using ProjectOrigin.WalletSystem.IntegrationTests.TestClassFixtures;
 using ProjectOrigin.WalletSystem.Server.Models;
 using ProjectOrigin.WalletSystem.Server.Repositories;
-using System;
-using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
 

--- a/src/ProjectOrigin.WalletSystem.IntegrationTests/Repositories/WalletRepositoryTests.cs
+++ b/src/ProjectOrigin.WalletSystem.IntegrationTests/Repositories/WalletRepositoryTests.cs
@@ -1,5 +1,6 @@
 using AutoFixture;
 using FluentAssertions;
+using ProjectOrigin.WalletSystem.IntegrationTests.TestClassFixtures;
 using ProjectOrigin.WalletSystem.Server.Models;
 using ProjectOrigin.WalletSystem.Server.Repositories;
 using System;

--- a/src/ProjectOrigin.WalletSystem.IntegrationTests/TestClassFixtures/GrpcTestFixture.cs
+++ b/src/ProjectOrigin.WalletSystem.IntegrationTests/TestClassFixtures/GrpcTestFixture.cs
@@ -22,16 +22,12 @@ using System.Net.Http;
 using Grpc.Net.Client;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Configuration.Memory;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using ProjectOrigin.WalletSystem.IntegrationTests.TestClassFixtures.GrpcHelpers;
 using Xunit.Abstractions;
-
-using ProjectOrigin.WalletSystem.Server.Extensions;
-using ProjectOrigin.WalletSystem.Server;
 
 namespace ProjectOrigin.WalletSystem.IntegrationTests.TestClassFixtures
 {

--- a/src/ProjectOrigin.WalletSystem.IntegrationTests/TestClassFixtures/GrpcTestFixture.cs
+++ b/src/ProjectOrigin.WalletSystem.IntegrationTests/TestClassFixtures/GrpcTestFixture.cs
@@ -22,12 +22,16 @@ using System.Net.Http;
 using Grpc.Net.Client;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Configuration.Memory;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using ProjectOrigin.WalletSystem.IntegrationTests.TestClassFixtures.GrpcHelpers;
 using Xunit.Abstractions;
+
+using ProjectOrigin.WalletSystem.Server.Extensions;
+using ProjectOrigin.WalletSystem.Server;
 
 namespace ProjectOrigin.WalletSystem.IntegrationTests.TestClassFixtures
 {

--- a/src/ProjectOrigin.WalletSystem.IntegrationTests/TestClassFixtures/IMessageBrokerFixture.cs
+++ b/src/ProjectOrigin.WalletSystem.IntegrationTests/TestClassFixtures/IMessageBrokerFixture.cs
@@ -1,0 +1,8 @@
+using System.Collections.Generic;
+
+namespace ProjectOrigin.WalletSystem.IntegrationTests.TestClassFixtures;
+
+public interface IMessageBrokerFixture
+{
+    Dictionary<string, string?> Configuration { get; }
+}

--- a/src/ProjectOrigin.WalletSystem.IntegrationTests/TestClassFixtures/InMemoryFixture.cs
+++ b/src/ProjectOrigin.WalletSystem.IntegrationTests/TestClassFixtures/InMemoryFixture.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+namespace ProjectOrigin.WalletSystem.IntegrationTests.TestClassFixtures;
+
+public class InMemoryFixture : IMessageBrokerFixture
+{
+    public Dictionary<string, string?> Configuration => new Dictionary<string, string?>()
+        {
+            {"MessageBroker:Type", "InMemory"},
+        };
+}

--- a/src/ProjectOrigin.WalletSystem.IntegrationTests/TestClassFixtures/PostgresDatabaseFixture.cs
+++ b/src/ProjectOrigin.WalletSystem.IntegrationTests/TestClassFixtures/PostgresDatabaseFixture.cs
@@ -6,7 +6,7 @@ using ProjectOrigin.WalletSystem.Server.Database.Postgres;
 using Testcontainers.PostgreSql;
 using Xunit;
 
-namespace ProjectOrigin.WalletSystem.IntegrationTests;
+namespace ProjectOrigin.WalletSystem.IntegrationTests.TestClassFixtures;
 
 public class PostgresDatabaseFixture : IAsyncLifetime
 {

--- a/src/ProjectOrigin.WalletSystem.IntegrationTests/TestClassFixtures/RabbitMqFixture.cs
+++ b/src/ProjectOrigin.WalletSystem.IntegrationTests/TestClassFixtures/RabbitMqFixture.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Testcontainers.RabbitMq;
+using Xunit;
+
+namespace ProjectOrigin.WalletSystem.IntegrationTests.TestClassFixtures;
+
+public class RabbitMqFixture : IMessageBrokerFixture, IAsyncLifetime
+{
+    private const string Username = "rabbitmq";
+    private const string Password = "rabbitmq";
+    private const int RabbitMqPort = 5672;
+    private readonly RabbitMqContainer _rabbitMqContainer;
+
+    public RabbitMqFixture()
+    {
+        _rabbitMqContainer = new RabbitMqBuilder()
+            .WithUsername(Username)
+            .WithPassword(Password)
+            .Build();
+    }
+
+    public Dictionary<string, string?> Configuration => new Dictionary<string, string?>()
+        {
+            {"MessageBroker:Type", "RabbitMq"},
+            {"MessageBroker:RabbitMq:Host", _rabbitMqContainer.Hostname},
+            {"MessageBroker:RabbitMq:Port", _rabbitMqContainer.GetMappedPublicPort(RabbitMqPort).ToString()},
+            {"MessageBroker:RabbitMq:Username", Username},
+            {"MessageBroker:RabbitMq:Password", Password},
+        };
+
+    public async Task InitializeAsync() => await _rabbitMqContainer.StartAsync().ConfigureAwait(false);
+    public async Task DisposeAsync() => await _rabbitMqContainer.StopAsync().ConfigureAwait(false);
+}

--- a/src/ProjectOrigin.WalletSystem.IntegrationTests/TestClassFixtures/RegistryFixture.cs
+++ b/src/ProjectOrigin.WalletSystem.IntegrationTests/TestClassFixtures/RegistryFixture.cs
@@ -12,7 +12,7 @@ using ProjectOrigin.HierarchicalDeterministicKeys.Interfaces;
 using ProjectOrigin.PedersenCommitment;
 using Xunit;
 
-namespace ProjectOrigin.WalletSystem.IntegrationTests;
+namespace ProjectOrigin.WalletSystem.IntegrationTests.TestClassFixtures;
 
 public class RegistryFixture : IAsyncLifetime
 {

--- a/src/ProjectOrigin.WalletSystem.IntegrationTests/TransferCertificateTests.cs
+++ b/src/ProjectOrigin.WalletSystem.IntegrationTests/TransferCertificateTests.cs
@@ -16,13 +16,23 @@ using FluentAssertions;
 
 namespace ProjectOrigin.WalletSystem.IntegrationTests;
 
-public class TransferCertificateTests : WalletSystemTestsBase, IClassFixture<RegistryFixture>
+public class TransferCertificateTests : WalletSystemTestsBase, IClassFixture<RegistryFixture>, IClassFixture<InMemoryFixture>
 {
     private readonly RegistryFixture _registryFixture;
     private readonly Fixture _fixture;
 
-    public TransferCertificateTests(GrpcTestFixture<Startup> grpcFixture, RegistryFixture registryFixture, PostgresDatabaseFixture dbFixture, ITestOutputHelper outputHelper)
-        : base(grpcFixture, dbFixture, outputHelper, registryFixture)
+    public TransferCertificateTests(
+            GrpcTestFixture<Startup> grpcFixture,
+            PostgresDatabaseFixture dbFixture,
+            InMemoryFixture inMemoryFixture,
+            RegistryFixture registryFixture,
+            ITestOutputHelper outputHelper)
+            : base(
+                  grpcFixture,
+                  dbFixture,
+                  inMemoryFixture,
+                  outputHelper,
+                  registryFixture)
     {
         _registryFixture = registryFixture;
         _fixture = new Fixture();

--- a/src/ProjectOrigin.WalletSystem.IntegrationTests/UnitOfWorkTests.cs
+++ b/src/ProjectOrigin.WalletSystem.IntegrationTests/UnitOfWorkTests.cs
@@ -2,6 +2,7 @@ using Dapper;
 using FluentAssertions;
 using ProjectOrigin.HierarchicalDeterministicKeys.Implementations;
 using ProjectOrigin.HierarchicalDeterministicKeys.Interfaces;
+using ProjectOrigin.WalletSystem.IntegrationTests.TestClassFixtures;
 using ProjectOrigin.WalletSystem.Server.Database;
 using ProjectOrigin.WalletSystem.Server.Database.Mapping;
 using ProjectOrigin.WalletSystem.Server.Models;

--- a/src/ProjectOrigin.WalletSystem.IntegrationTests/VerifySlicesWorkerTests.cs
+++ b/src/ProjectOrigin.WalletSystem.IntegrationTests/VerifySlicesWorkerTests.cs
@@ -12,13 +12,23 @@ using Xunit.Abstractions;
 
 namespace ProjectOrigin.WalletSystem.IntegrationTests;
 
-public class VerifySlicesWorkerTests : WalletSystemTestsBase, IClassFixture<RegistryFixture>
+public class VerifySlicesWorkerTests : WalletSystemTestsBase, IClassFixture<InMemoryFixture>, IClassFixture<RegistryFixture>
 {
     private RegistryFixture _registryFixture;
     private Fixture _fixture;
 
-    public VerifySlicesWorkerTests(GrpcTestFixture<Startup> grpcFixture, RegistryFixture registryFixture, PostgresDatabaseFixture dbFixture, ITestOutputHelper outputHelper)
-        : base(grpcFixture, dbFixture, outputHelper, registryFixture)
+    public VerifySlicesWorkerTests(
+        GrpcTestFixture<Startup> grpcFixture,
+        PostgresDatabaseFixture dbFixture,
+        InMemoryFixture inMemoryFixture,
+        RegistryFixture registryFixture,
+        ITestOutputHelper outputHelper)
+        : base(
+              grpcFixture,
+              dbFixture,
+              inMemoryFixture,
+              outputHelper,
+              registryFixture)
     {
         _registryFixture = registryFixture;
         _fixture = new Fixture();

--- a/src/ProjectOrigin.WalletSystem.Server/Extensions/IBusRegistrationConfiguratorExtensions.cs
+++ b/src/ProjectOrigin.WalletSystem.Server/Extensions/IBusRegistrationConfiguratorExtensions.cs
@@ -33,7 +33,7 @@ public static class IBusRegistrationConfiguratorExtensions
                 break;
 
             default:
-                throw new NotSupportedException($"Persistance type ”{options.Type}” not supported");
+                throw new NotSupportedException($"Message broker type ”{options.Type}” not supported");
         }
 
     }

--- a/src/ProjectOrigin.WalletSystem.Server/Extensions/IBusRegistrationConfiguratorExtensions.cs
+++ b/src/ProjectOrigin.WalletSystem.Server/Extensions/IBusRegistrationConfiguratorExtensions.cs
@@ -1,4 +1,3 @@
-
 using System;
 using MassTransit;
 using ProjectOrigin.WalletSystem.Server.Options;

--- a/src/ProjectOrigin.WalletSystem.Server/Extensions/IBusRegistrationConfiguratorExtensions.cs
+++ b/src/ProjectOrigin.WalletSystem.Server/Extensions/IBusRegistrationConfiguratorExtensions.cs
@@ -1,0 +1,52 @@
+
+using System;
+using MassTransit;
+using ProjectOrigin.WalletSystem.Server.Options;
+using ProjectOrigin.WalletSystem.Server.Serialization;
+
+public static class IBusRegistrationConfiguratorExtensions
+{
+    public static void ConfigureMassTransitTransport(this IBusRegistrationConfigurator busConfig, MessageBrokerOptions options)
+    {
+        switch (options.Type)
+        {
+            case MessageBrokerType.InMemory:
+                Serilog.Log.Logger.Warning("MessageBroker.Type is set to InMemory, this is not recommended for production use, messages are not durable");
+
+                busConfig.UsingInMemory((context, cfg) =>
+                {
+                    cfg.ConfigureDefaults(context);
+                });
+                break;
+
+            case MessageBrokerType.RabbitMq:
+                busConfig.UsingRabbitMq((context, cfg) =>
+                {
+                    cfg.ConfigureDefaults(context);
+
+                    var rabbitOption = options.RabbitMq!;
+                    cfg.Host(rabbitOption.Host, rabbitOption.Port, "/", h =>
+                    {
+                        h.Username(rabbitOption.Username);
+                        h.Password(rabbitOption.Password);
+                    });
+                });
+                break;
+
+            default:
+                throw new NotSupportedException($"Persistance type ”{options.Type}” not supported");
+        }
+
+    }
+
+    private static void ConfigureDefaults<T>(this IBusFactoryConfigurator<T> cfg, IBusRegistrationContext context) where T : IReceiveEndpointConfigurator
+    {
+        cfg.ConfigureEndpoints(context);
+
+        cfg.ConfigureJsonSerializerOptions(options =>
+        {
+            options.Converters.Add(new TransactionConverter());
+            return options;
+        });
+    }
+}

--- a/src/ProjectOrigin.WalletSystem.Server/Extensions/IConfigurationExtensions.cs
+++ b/src/ProjectOrigin.WalletSystem.Server/Extensions/IConfigurationExtensions.cs
@@ -1,10 +1,10 @@
 using System;
+using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using ProjectOrigin.WalletSystem.Server.Database;
-using ProjectOrigin.WalletSystem.Server.Database.Postgres;
 using Serilog;
 using Serilog.Enrichers.Span;
 using Serilog.Formatting.Json;
@@ -13,6 +13,25 @@ namespace ProjectOrigin.WalletSystem.Server.Extensions;
 
 public static class IConfigurationExtensions
 {
+    public static T GetValid<T>(this IConfiguration configuration) where T : IValidatableObject
+    {
+        try
+        {
+            var value = configuration.Get<T>();
+
+            if (value is null)
+                throw new ArgumentNullException($"Configuration value of type {typeof(T)} is null");
+
+            Validator.ValidateObject(value, new ValidationContext(value), true);
+
+            return value;
+        }
+        catch (InvalidOperationException ex) when (ex.Message.Contains("Failed to convert configuration value"))
+        {
+            throw new ValidationException($"Configuration value of type {typeof(T)} is invalid", ex);
+        }
+    }
+
     public static IRepositoryUpgrader GetRepositoryUpgrader(this IConfiguration configuration, Serilog.ILogger logger)
     {
         var services = new ServiceCollection();

--- a/src/ProjectOrigin.WalletSystem.Server/Options/MessageBrokerOptions.cs
+++ b/src/ProjectOrigin.WalletSystem.Server/Options/MessageBrokerOptions.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace ProjectOrigin.WalletSystem.Server.Options;
+
+public class MessageBrokerOptions : IValidatableObject
+{
+    public MessageBrokerType Type { get; set; }
+
+    public RabbitMqOptions? RabbitMq { get; set; } = null;
+
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        List<ValidationResult> results = new();
+        switch (Type)
+        {
+            case MessageBrokerType.InMemory:
+                break;
+
+            case MessageBrokerType.RabbitMq:
+                if (RabbitMq is null)
+                    results.Add(new ValidationResult($"Not supported message broker type: ”{Type}”"));
+                else
+                    Validator.TryValidateObject(RabbitMq, new ValidationContext(RabbitMq), results, true);
+                break;
+
+            default:
+                results.Add(new ValidationResult($"Not supported message broker type: ”{Type}”"));
+                break;
+        }
+
+        return results;
+    }
+}

--- a/src/ProjectOrigin.WalletSystem.Server/Options/MessageBrokerType.cs
+++ b/src/ProjectOrigin.WalletSystem.Server/Options/MessageBrokerType.cs
@@ -1,0 +1,6 @@
+using System.Text.Json.Serialization;
+
+namespace ProjectOrigin.WalletSystem.Server.Options;
+
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum MessageBrokerType { InMemory, RabbitMq }

--- a/src/ProjectOrigin.WalletSystem.Server/Options/RabbitMqOptions.cs
+++ b/src/ProjectOrigin.WalletSystem.Server/Options/RabbitMqOptions.cs
@@ -1,0 +1,18 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace ProjectOrigin.WalletSystem.Server.Options;
+
+public class RabbitMqOptions
+{
+    [Required]
+    public string Host { get; set; } = string.Empty;
+
+    [Required, Range(1, 65535)]
+    public ushort Port { get; set; } = 0;
+
+    [Required]
+    public string Username { get; set; } = string.Empty;
+
+    [Required]
+    public string Password { get; set; } = string.Empty;
+}

--- a/src/ProjectOrigin.WalletSystem.Server/appsettings.Development.json
+++ b/src/ProjectOrigin.WalletSystem.Server/appsettings.Development.json
@@ -15,5 +15,8 @@
     "RegistryUrls": {
         "RegistryA": "https://registry.example.com",
         "RegistryB": "https://another.registry.example.com"
+    },
+    "MessageBroker": {
+        "Type": "InMemory"
     }
 }


### PR DESCRIPTION
This is a breaking change, the value `messageBroker.type` must be set to `inMemory` to keep parity with older release.

> Warning: InMemory is not for production!

- Added messageBroker configuration
- Added RabbitMQ support
- Added RabbitMQ Operator support on chart
- Added test to verify configuration
- Added test that RabbitMq configuration can start container

Fixes: #48 