### PR TITLE
Added configurable replica count in helm chart

### DIFF
--- a/charts/project-origin-wallet/templates/deployment-wallet.yaml
+++ b/charts/project-origin-wallet/templates/deployment-wallet.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app: po-wallet
 spec:
-  replicas: 3
+  replicas: {{ .Values.wallet.replicaCount }}
   selector:
     matchLabels:
       app: po-wallet

--- a/charts/project-origin-wallet/values.yaml
+++ b/charts/project-origin-wallet/values.yaml
@@ -33,7 +33,8 @@ messageBroker:
 
 # wallet defines the service configuration for the wallet server
 wallet:
-
+  # replicas defines the number of wallet server instances to run
+  replicaCount: 3
   # externalUrl defines the external url to use for the wallet server
   externalUrl:
 


### PR DESCRIPTION
The number of wallet containers deployed can now be set using the following in values.yaml file

```yaml
wallet:
   replicaCount: 5
```

fixes #84