### PR TITLE
Fix missing quote around boolean and typo in test

### DIFF
--- a/charts/project-origin-wallet/run_kind_test.sh
+++ b/charts/project-origin-wallet/run_kind_test.sh
@@ -40,7 +40,7 @@ image:
 config:
   externalUrl: http://wallet.example:80
   jwt:
-    allowAnyJwtToken: truee
+    allowAnyJwtToken: true
 
 messageBroker:
   type: rabbitmqOperator

--- a/charts/project-origin-wallet/templates/deployment-wallet.yaml
+++ b/charts/project-origin-wallet/templates/deployment-wallet.yaml
@@ -105,7 +105,7 @@ spec:
             - name: jwt__audience
               value: {{ .Values.config.jwt.audience }}
             - name: jwt__allowAnyJwtToken
-              value: {{ .Values.config.jwt.allowAnyJwtToken }}
+              value: {{ .Values.config.jwt.allowAnyJwtToken | quote }}
             {{- range  $i, $issuer := .Values.config.jwt.issuers }}
             - name: jwt__issuers__{{ $i }}__name
               value: {{ $issuer.name }}


### PR DESCRIPTION
This pull request fixes a missing quote around a boolean value and a typo in a test. The missing quote caused an error in the code, while the typo affected the accuracy of the test. These changes ensure that the code functions correctly and the test produces accurate results.