### PR TITLE
Added wallet apis to REST endpoint

### DIFF
--- a/charts/project-origin-wallet/templates/deployment-wallet.yaml
+++ b/charts/project-origin-wallet/templates/deployment-wallet.yaml
@@ -35,7 +35,7 @@ spec:
             - name: ServiceOptions__EndpointAddress
               value: {{ required "A valid externalUrl is required!"  .Values.config.externalUrl }}
             - name: RestApiOptions__PathBase
-              value: {{ .Values.rest.pathBase }}
+              value: {{ .Values.config.pathBase }}
             {{- if eq .Values.messageBroker.type "inMemory" }}
             - name: MessageBroker__Type
               value: InMemory

--- a/charts/project-origin-wallet/values.yaml
+++ b/charts/project-origin-wallet/values.yaml
@@ -18,8 +18,13 @@ service:
 
 # config holds general configuration for the wallet server
 config:
-  # externalUrl defines the external url to use for the wallet server
+  # externalUrl defines the external url to use for the wallet server, this should be the publically accessible and resolvable url of the wallet server.
+  # example: http://wallet.example.com/api or https://example.com/wallet/api
+  # This should include the pathBase
   externalUrl:
+
+  # pathBase defines the base part of all paths in the api of the wallet server, defaults to /api
+  pathBase: /api
 
   # jwt defines the configuration for the authentication of jwt tokens
   jwt:
@@ -100,8 +105,3 @@ persistance:
 
     # storage defines the storage configuration for the database
     size: 10Gi
-
-# rest defines the configuration of the REST API
-rest:
-  # pathBase defines the base part of all paths in the api
-  pathBase: /api

--- a/src/ProjectOrigin.WalletSystem.IntegrationTests/ApiTests.open_api_specification_not_changed.verified.txt
+++ b/src/ProjectOrigin.WalletSystem.IntegrationTests/ApiTests.open_api_specification_not_changed.verified.txt
@@ -327,6 +327,200 @@
           }
         }
       }
+    },
+    "/v1/wallets": {
+      "post": {
+        "tags": [
+          "Wallet"
+        ],
+        "summary": "Creates a new wallet for the user.",
+        "description": "Currently, only **one wallet** per user is supported.\r\nThe wallet is created with a private key, which is used to generate sub-public-keys for each certificate-slice.\r\nThe private key can be provided, but it is optional, if omittted a random one is generated.",
+        "requestBody": {
+          "description": "The private key to import. If not provided, a new private key will be generated.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateWalletRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateWalletRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateWalletRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "The wallet was created.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateWalletResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "If private key is invalid or if wallet for user already exists.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "If the user is not authenticated."
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Wallet"
+        ],
+        "summary": "Gets all wallets for the user.",
+        "responses": {
+          "200": {
+            "description": "The wallets were found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WalletRecordResultList"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "If the user is not authenticated."
+          }
+        }
+      }
+    },
+    "/v1/wallets/{walletId}": {
+      "get": {
+        "tags": [
+          "Wallet"
+        ],
+        "summary": "Gets a specific wallet for the user.",
+        "parameters": [
+          {
+            "name": "walletId",
+            "in": "path",
+            "description": "The ID of the wallet to get.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The wallet was found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WalletRecord"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "If the user is not authenticated."
+          },
+          "404": {
+            "description": "If the wallet specified is not found for the user."
+          }
+        }
+      }
+    },
+    "/v1/wallets/{walletId}/endpoints": {
+      "post": {
+        "tags": [
+          "Wallet"
+        ],
+        "summary": "Creates a new wallet endpoint on the users wallet, which can be sent to other services to receive certificate-slices.",
+        "parameters": [
+          {
+            "name": "walletId",
+            "in": "path",
+            "description": "The ID of the wallet to create the endpoint on.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "The wallet endpoint was created.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateWalletEndpointResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "If the user is not authenticated."
+          },
+          "404": {
+            "description": "If the wallet specified is not found for the user."
+          }
+        }
+      }
+    },
+    "/v1/external-endpoints": {
+      "post": {
+        "tags": [
+          "Wallet"
+        ],
+        "summary": "Creates a new external endpoint for the user, which can user can use to send certficates to the other wallet.",
+        "requestBody": {
+          "description": "The request to create the external endpoint.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateExternalEndpointRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateExternalEndpointRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateExternalEndpointRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "The external endpoint was created.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateExternalEndpointResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "If the user is not authenticated."
+          }
+        }
+      }
     }
   },
   "components": {
@@ -489,6 +683,67 @@
         },
         "additionalProperties": false
       },
+      "CreateExternalEndpointRequest": {
+        "type": "object",
+        "properties": {
+          "walletReference": {
+            "$ref": "#/components/schemas/WalletEndpointReference"
+          },
+          "textReference": {
+            "type": "string",
+            "description": "The text reference for the wallet, one wants to create a link to."
+          }
+        },
+        "additionalProperties": false,
+        "description": "Request to create a new external endpoint."
+      },
+      "CreateExternalEndpointResponse": {
+        "type": "object",
+        "properties": {
+          "receiverId": {
+            "type": "string",
+            "description": "The ID of the created external endpoint.",
+            "format": "uuid"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Response to create a new external endpoint."
+      },
+      "CreateWalletEndpointResponse": {
+        "type": "object",
+        "properties": {
+          "walletReference": {
+            "$ref": "#/components/schemas/WalletEndpointReference"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Response to create a new wallet endpoint on the users wallet."
+      },
+      "CreateWalletRequest": {
+        "type": "object",
+        "properties": {
+          "privateKey": {
+            "type": "string",
+            "description": "The private key to import. If not provided, a private key will be generated.",
+            "format": "byte",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Request to create a new wallet."
+      },
+      "CreateWalletResponse": {
+        "type": "object",
+        "properties": {
+          "walletId": {
+            "type": "string",
+            "description": "The ID of the created wallet.",
+            "format": "uuid"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Response to create a new wallet."
+      },
       "FederatedStreamId": {
         "type": "object",
         "properties": {
@@ -547,6 +802,37 @@
         },
         "additionalProperties": false
       },
+      "IHDPublicKey": {
+        "type": "string",
+        "additionalProperties": false
+      },
+      "ProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "nullable": true
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "detail": {
+            "type": "string",
+            "nullable": true
+          },
+          "instance": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": { }
+      },
       "TimeAggregate": {
         "enum": [
           "actual",
@@ -594,6 +880,51 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/Transfer"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "WalletEndpointReference": {
+        "type": "object",
+        "properties": {
+          "version": {
+            "type": "integer",
+            "description": "The version of the ReceiveSlice API.",
+            "format": "int32"
+          },
+          "endpoint": {
+            "type": "string",
+            "description": "The url endpoint of where the wallet is hosted.",
+            "format": "uri"
+          },
+          "publicKey": {
+            "$ref": "#/components/schemas/IHDPublicKey"
+          }
+        },
+        "additionalProperties": false
+      },
+      "WalletRecord": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "publicKey": {
+            "$ref": "#/components/schemas/IHDPublicKey"
+          }
+        },
+        "additionalProperties": false,
+        "description": "A wallet record"
+      },
+      "WalletRecordResultList": {
+        "type": "object",
+        "properties": {
+          "result": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WalletRecord"
             }
           }
         },

--- a/src/ProjectOrigin.WalletSystem.IntegrationTests/ApiTests.open_api_specification_not_changed.verified.txt
+++ b/src/ProjectOrigin.WalletSystem.IntegrationTests/ApiTests.open_api_specification_not_changed.verified.txt
@@ -917,6 +917,7 @@
           },
           "position": {
             "type": "integer",
+            "description": "The sub-position of the publicKey used on the slice on the registry.",
             "format": "int32"
           },
           "certificateId": {

--- a/src/ProjectOrigin.WalletSystem.IntegrationTests/ApiTests.open_api_specification_not_changed.verified.txt
+++ b/src/ProjectOrigin.WalletSystem.IntegrationTests/ApiTests.open_api_specification_not_changed.verified.txt
@@ -223,6 +223,60 @@
         }
       }
     },
+    "/v1/slices": {
+      "post": {
+        "tags": [
+          "Slices"
+        ],
+        "summary": "Receive a certificate-slice from another wallet.",
+        "description": "This request is used to receive a certificate-slice from another wallet, which is then stored in the local wallet.\r\nThe endpoint is verified to exists within the wallet system, otherwise a 404 will be returned.\r\nThe endpoint will return 202 Accepted was initial validation has succeeded.\r\nThe certificate-slice will further verified with data from the registry in a seperate thread.",
+        "requestBody": {
+          "description": "Contains the data",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReceiveRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReceiveRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReceiveRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "202": {
+            "description": "The slice was accepted."
+          },
+          "400": {
+            "description": "Public key could not be decoded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Receiver endpoint not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/transfers": {
       "get": {
         "tags": [
@@ -802,6 +856,26 @@
         },
         "additionalProperties": false
       },
+      "HashedAttribute": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string",
+            "description": "The key of the attribute."
+          },
+          "value": {
+            "type": "string",
+            "description": "The value of the attribute."
+          },
+          "salt": {
+            "type": "string",
+            "description": "The salt used to hash the attribute.",
+            "format": "byte"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Hashed attribute with salt."
+      },
       "IHDPublicKey": {
         "type": "string",
         "additionalProperties": false
@@ -832,6 +906,42 @@
           }
         },
         "additionalProperties": { }
+      },
+      "ReceiveRequest": {
+        "type": "object",
+        "properties": {
+          "publicKey": {
+            "type": "string",
+            "description": "The public key of the receiving wallet.",
+            "format": "byte"
+          },
+          "position": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "certificateId": {
+            "$ref": "#/components/schemas/FederatedStreamId"
+          },
+          "quantity": {
+            "type": "integer",
+            "description": "The quantity of the slice.",
+            "format": "int32"
+          },
+          "randomR": {
+            "type": "string",
+            "description": "The random R used to generate the pedersen commitment with the quantitiy.",
+            "format": "byte"
+          },
+          "hashedAttributes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/HashedAttribute"
+            },
+            "description": "List of hashed attributes, their values and salts so the receiver can access the data."
+          }
+        },
+        "additionalProperties": false,
+        "description": "Request to receive a certificate-slice from another wallet."
       },
       "TimeAggregate": {
         "enum": [

--- a/src/ProjectOrigin.WalletSystem.IntegrationTests/Extensions/HttpTaskExtensions.cs
+++ b/src/ProjectOrigin.WalletSystem.IntegrationTests/Extensions/HttpTaskExtensions.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Net.Http;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+using FluentAssertions;
+using ProjectOrigin.HierarchicalDeterministicKeys.Implementations;
+using ProjectOrigin.WalletSystem.Server.Serialization;
+
+namespace ProjectOrigin.WalletSystem.IntegrationTests;
+
+public static class HttpTaskExtensions
+{
+    private static Lazy<JsonSerializerOptions> JsonOptions = new Lazy<JsonSerializerOptions>(() =>
+    {
+        var options = new JsonSerializerOptions(JsonSerializerDefaults.Web);
+        options.Converters.Add(new IHDPublicKeyConverter(new Secp256k1Algorithm()));
+        options.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.CamelCase));
+        return options;
+    });
+
+    public static async Task<T> ParseJson<T>(this Task<HttpResponseMessage> httpResponse)
+    {
+        var response = await httpResponse;
+        response.IsSuccessStatusCode.Should().BeTrue();
+        var responseString = await response.Content.ReadAsStringAsync();
+
+        return JsonSerializer.Deserialize<T>(responseString, JsonOptions.Value)
+            ?? throw new Exception("Failed to deserialize");
+    }
+}

--- a/src/ProjectOrigin.WalletSystem.IntegrationTests/FlowTests/AbstractFlowTests.cs
+++ b/src/ProjectOrigin.WalletSystem.IntegrationTests/FlowTests/AbstractFlowTests.cs
@@ -9,6 +9,7 @@ using Google.Protobuf;
 using Xunit;
 using System;
 using System.Linq;
+using Xunit.Sdk;
 
 namespace ProjectOrigin.WalletSystem.IntegrationTests;
 
@@ -74,7 +75,7 @@ public abstract class AbstractFlowTests : WalletSystemTestsBase, IClassFixture<R
             {
                 return await func();
             }
-            catch (Exception)
+            catch (XunitException)
             {
                 await Task.Delay(1000);
             }

--- a/src/ProjectOrigin.WalletSystem.IntegrationTests/FlowTests/RestFlowTest.cs
+++ b/src/ProjectOrigin.WalletSystem.IntegrationTests/FlowTests/RestFlowTest.cs
@@ -91,26 +91,9 @@ public class RestFlowTest : AbstractFlowTests
         }, TimeSpan.FromMinutes(1));
     }
 
-    private static HttpContent ToJsonContent(object obj)
+    private static StringContent ToJsonContent(object obj)
     {
         var json = JsonSerializer.Serialize(obj);
         return new StringContent(json, Encoding.UTF8, "application/json");
-    }
-}
-
-
-public static class HttpTaskExtensions
-{
-    public static async Task<T> ParseJson<T>(this Task<HttpResponseMessage> httpResponse)
-    {
-        var response = await httpResponse;
-        response.IsSuccessStatusCode.Should().BeTrue();
-        var responseString = await response.Content.ReadAsStringAsync();
-
-        var options = new JsonSerializerOptions(JsonSerializerDefaults.Web);
-        options.Converters.Add(new IHDPublicKeyConverter(new Secp256k1Algorithm()));
-        options.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.CamelCase));
-
-        return JsonSerializer.Deserialize<T>(responseString, options) ?? throw new Exception("Failed to deserialize");
     }
 }

--- a/src/ProjectOrigin.WalletSystem.IntegrationTests/FlowTests/RestFlowTest.cs
+++ b/src/ProjectOrigin.WalletSystem.IntegrationTests/FlowTests/RestFlowTest.cs
@@ -1,0 +1,83 @@
+using ProjectOrigin.WalletSystem.IntegrationTests.TestClassFixtures;
+using ProjectOrigin.WalletSystem.Server;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+using FluentAssertions;
+using System.Net.Http;
+using System.Text;
+using System.Net.Http.Headers;
+using System;
+using AutoFixture;
+using System.Collections.Generic;
+using ProjectOrigin.WalletSystem.Server.Services.REST.v1;
+using ProjectOrigin.WalletSystem.Server.Serialization;
+using ProjectOrigin.HierarchicalDeterministicKeys.Implementations;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace ProjectOrigin.WalletSystem.IntegrationTests;
+
+public class RestFlowTest : AbstractFlowTests
+{
+    private readonly RegistryFixture _registryFixture;
+    private readonly JwtTokenIssuerFixture _jwtTokenIssuer;
+
+    public RestFlowTest(
+            TestServerFixture<Startup> serverFixture,
+            PostgresDatabaseFixture dbFixture,
+            InMemoryFixture inMemoryFixture,
+            JwtTokenIssuerFixture jwtTokenIssuerFixture,
+            RegistryFixture registryFixture,
+            ITestOutputHelper outputHelper)
+            : base(
+                  serverFixture,
+                  dbFixture,
+                  inMemoryFixture,
+                  jwtTokenIssuerFixture,
+                  outputHelper,
+                  registryFixture)
+    {
+        _registryFixture = registryFixture;
+        _jwtTokenIssuer = jwtTokenIssuerFixture;
+    }
+
+    [Fact]
+    public async Task Transfer_SingleSlice_LocalWallet()
+    {
+        // Arrange
+        var subject = Guid.NewGuid().ToString();
+
+        var client = _serverFixture.CreateHttpClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _jwtTokenIssuer.GenerateToken(subject, _fixture.Create<string>()));
+
+        // create wallet
+        var walletResponse = await client.PostAsync("v1/wallets", ToJsonContent(new { })).ParseJson<CreateWalletResponse>();
+
+        // create wallet endpoint
+        await client.PostAsync($"v1/wallets/{walletResponse.WalletId}/endpoints", ToJsonContent(new { })).ParseJson<CreateWalletEndpointResponse>();
+    }
+
+    private static HttpContent ToJsonContent(object obj)
+    {
+        var json = JsonSerializer.Serialize(obj);
+        return new StringContent(json, Encoding.UTF8, "application/json");
+    }
+}
+
+
+public static class HttpTaskExtensions
+{
+    public static async Task<T> ParseJson<T>(this Task<HttpResponseMessage> httpResponse)
+    {
+        var response = await httpResponse;
+        response.IsSuccessStatusCode.Should().BeTrue();
+        var responseString = await response.Content.ReadAsStringAsync();
+
+        var options = new JsonSerializerOptions(JsonSerializerDefaults.Web);
+        options.Converters.Add(new IHDPublicKeyConverter(new Secp256k1Algorithm()));
+        options.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.CamelCase));
+
+        return JsonSerializer.Deserialize<T>(responseString, options) ?? throw new Exception("Failed to deserialize");
+    }
+}

--- a/src/ProjectOrigin.WalletSystem.IntegrationTests/GrpcTests.cs
+++ b/src/ProjectOrigin.WalletSystem.IntegrationTests/GrpcTests.cs
@@ -58,7 +58,7 @@ public class GrpcTests : WalletSystemTestsBase, IClassFixture<InMemoryFixture>
 
             var wallet = await walletRepository.GetWallet(endpoint!.WalletId);
             wallet.Should().NotBeNull();
-            wallet.Owner.Should().Be(subject);
+            wallet!.Owner.Should().Be(subject);
         }
     }
 

--- a/src/ProjectOrigin.WalletSystem.IntegrationTests/REST/SlicesControllerTests.cs
+++ b/src/ProjectOrigin.WalletSystem.IntegrationTests/REST/SlicesControllerTests.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using AutoFixture;
+using FluentAssertions;
+using MassTransit;
+using MassTransit.Testing;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using ProjectOrigin.HierarchicalDeterministicKeys.Implementations;
+using ProjectOrigin.WalletSystem.IntegrationTests.TestClassFixtures;
+using ProjectOrigin.WalletSystem.IntegrationTests.TestExtensions;
+using ProjectOrigin.WalletSystem.Server.CommandHandlers;
+using ProjectOrigin.WalletSystem.Server.Database;
+using ProjectOrigin.WalletSystem.Server.Models;
+using ProjectOrigin.WalletSystem.Server.Services.REST.v1;
+using Xunit;
+
+namespace ProjectOrigin.WalletSystem.IntegrationTests;
+
+public class SlicesControllerTests : IClassFixture<PostgresDatabaseFixture>
+{
+    private readonly Fixture _fixture;
+    private readonly Secp256k1Algorithm _hdAlgorithm;
+    private readonly PostgresDatabaseFixture _dbFixture;
+    private readonly IUnitOfWork _unitOfWork;
+
+    public SlicesControllerTests(PostgresDatabaseFixture postgresDatabaseFixture)
+    {
+        _fixture = new Fixture();
+        _hdAlgorithm = new Secp256k1Algorithm();
+        _dbFixture = postgresDatabaseFixture;
+        _unitOfWork = _dbFixture.CreateUnitOfWork();
+    }
+
+    [Fact]
+    public async Task ReceiveSlice_EndpointNotFound()
+    {
+        // Arrange
+        var controller = new SlicesController();
+
+        // Act
+        var result = await controller.ReceiveSlice(
+            _unitOfWork,
+            _hdAlgorithm,
+            Substitute.For<IBus>(),
+            _fixture.Create<ReceiveRequest>() with
+            {
+                PublicKey = _hdAlgorithm.GenerateNewPrivateKey().Neuter().Export().ToArray()
+            }
+            );
+
+        // Assert
+        result.Result.Should().BeOfType<NotFoundObjectResult>()
+            .Which.Value.Should().Be("Endpoint not found for public key.");
+    }
+
+    [Fact]
+    public async Task ReceiveSlice_InvalidKey()
+    {
+        // Arrange
+        var controller = new SlicesController();
+
+        // Act
+        var result = await controller.ReceiveSlice(
+            _unitOfWork,
+            _hdAlgorithm,
+            Substitute.For<IBus>(),
+            _fixture.Create<ReceiveRequest>()
+            );
+
+        // Assert
+        result.Result.Should().BeOfType<BadRequestObjectResult>()
+            .Which.Value.Should().Be("Invalid public key.");
+    }
+
+    [Fact]
+    public async Task ReceiveSlice_VerifySliceCommand_Published()
+    {
+        // Arrange
+        var subject = _fixture.Create<string>();
+        var controller = new SlicesController();
+
+        var walletId = Guid.NewGuid();
+
+        await _unitOfWork.WalletRepository.Create(new Wallet
+        {
+            Id = walletId,
+            Owner = subject,
+            PrivateKey = _hdAlgorithm.GenerateNewPrivateKey(),
+        });
+
+        var endpoint = await _unitOfWork.WalletRepository.CreateWalletEndpoint(walletId);
+
+        await using var provider = new ServiceCollection()
+            .AddMassTransitTestHarness(x =>
+            {
+            })
+            .BuildServiceProvider(true);
+
+        var harness = provider.GetRequiredService<ITestHarness>();
+        await harness.Start();
+
+        var request = new ReceiveRequest
+        {
+            PublicKey = endpoint.PublicKey.Export().ToArray(),
+            Position = _fixture.Create<uint>(),
+            CertificateId = new FederatedStreamId
+            {
+                Registry = _fixture.Create<string>(),
+                StreamId = Guid.NewGuid(),
+            },
+            Quantity = _fixture.Create<uint>(),
+            RandomR = _fixture.Create<byte[]>(),
+            HashedAttributes = new List<HashedAttribute>(){
+                new HashedAttribute
+                {
+                    Key = _fixture.Create<string>(),
+                    Value = _fixture.Create<string>(),
+                    Salt = _fixture.Create<byte[]>(),
+                }
+            }
+        };
+
+        // Act
+        var result = await controller.ReceiveSlice(
+            _unitOfWork,
+            _hdAlgorithm,
+            harness.Bus,
+            request
+            );
+
+        // Assert
+        result.Result.Should().BeOfType<AcceptedResult>()
+          .Which.Value.Should().BeOfType<ReceiveResponse>();
+
+        var sentMessage = harness.Published.Select<VerifySliceCommand>().Should().ContainSingle();
+        var sentCommand = sentMessage.Which.Context.Message;
+
+        sentCommand.WalletId.Should().Be(walletId);
+        sentCommand.WalletEndpointId.Should().Be(endpoint.Id);
+        sentCommand.WalletEndpointPosition.Should().Be((int)request.Position);
+        sentCommand.Registry.Should().Be(request.CertificateId.Registry);
+        sentCommand.CertificateId.Should().Be(request.CertificateId.StreamId);
+        sentCommand.Quantity.Should().Be(request.Quantity);
+        sentCommand.RandomR.Should().BeEquivalentTo(request.RandomR);
+        sentCommand.HashedAttributes.Should().BeEquivalentTo(request.HashedAttributes);
+    }
+}

--- a/src/ProjectOrigin.WalletSystem.IntegrationTests/REST/WalletControllerTests.cs
+++ b/src/ProjectOrigin.WalletSystem.IntegrationTests/REST/WalletControllerTests.cs
@@ -1,0 +1,476 @@
+using System;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using AutoFixture;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using ProjectOrigin.HierarchicalDeterministicKeys.Implementations;
+using ProjectOrigin.WalletSystem.IntegrationTests.TestClassFixtures;
+using ProjectOrigin.WalletSystem.IntegrationTests.TestExtensions;
+using ProjectOrigin.WalletSystem.Server.Database;
+using ProjectOrigin.WalletSystem.Server.Options;
+using ProjectOrigin.WalletSystem.Server.Services.REST.v1;
+using Xunit;
+
+namespace ProjectOrigin.WalletSystem.IntegrationTests;
+
+public class WalletControllerTests : IClassFixture<PostgresDatabaseFixture>
+{
+    private readonly Fixture _fixture;
+    private readonly Secp256k1Algorithm _hdAlgorithm;
+    private readonly PostgresDatabaseFixture _dbFixture;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly IOptions<ServiceOptions> _options;
+
+    public WalletControllerTests(PostgresDatabaseFixture postgresDatabaseFixture)
+    {
+        _fixture = new Fixture();
+        _hdAlgorithm = new Secp256k1Algorithm();
+        _dbFixture = postgresDatabaseFixture;
+        _unitOfWork = _dbFixture.CreateUnitOfWork();
+
+        _options = Options.Create(new ServiceOptions
+        {
+            EndpointAddress = new Uri("https://example.com")
+        });
+    }
+
+    [Fact]
+    public async Task Verify_Unauthorized()
+    {
+        // Arrange
+        var controller = new WalletController();
+
+        // Act
+        var result = await controller.CreateWallet(
+            _unitOfWork,
+            _hdAlgorithm,
+            _options,
+            new CreateWalletRequest());
+
+        // Assert
+        result.Result.Should().BeOfType<UnauthorizedResult>();
+    }
+
+    [Fact]
+    public async Task Verify_InvalidKey()
+    {
+        // Arrange
+        var subject = _fixture.Create<string>();
+        var controller = new WalletController()
+        {
+            ControllerContext = CreateContextWithUser(subject)
+        };
+
+        // Act
+        var result = await controller.CreateWallet(
+            _unitOfWork,
+            _hdAlgorithm,
+            _options,
+            new CreateWalletRequest()
+            {
+                PrivateKey = _fixture.Create<byte[]>()
+            });
+
+        // Assert
+        result.Result.Should().BeOfType<BadRequestObjectResult>()
+            .Which.Value.Should().Be("Invalid private key.");
+    }
+
+    [Fact]
+    public async Task Verify_ValidWithValidKey()
+    {
+        // Arrange
+        var subject = _fixture.Create<string>();
+        var controller = new WalletController()
+        {
+            ControllerContext = CreateContextWithUser(subject)
+        };
+
+        // Act
+        var result = await controller.CreateWallet(
+            _unitOfWork,
+            _hdAlgorithm,
+            _options,
+            new CreateWalletRequest()
+            {
+                PrivateKey = _hdAlgorithm.GenerateNewPrivateKey().Export().ToArray()
+            });
+
+        // Assert
+        result
+            .Result.Should().BeOfType<CreatedResult>()
+            .Which.Value.Should().BeOfType<CreateWalletResponse>()
+            .Which.WalletId.Should().NotBeEmpty();
+
+        var wallet = await _unitOfWork.WalletRepository.GetWallet(subject);
+        wallet.Should().NotBeNull();
+        wallet!.PrivateKey.Should().BeEquivalentTo(_hdAlgorithm.GenerateNewPrivateKey());
+    }
+
+    [Fact]
+    public async Task Verify_Valid()
+    {
+        // Arrange
+        var subject = _fixture.Create<string>();
+        var controller = new WalletController()
+        {
+            ControllerContext = CreateContextWithUser(subject)
+        };
+
+        // Act
+        var result = await controller.CreateWallet(
+            _unitOfWork,
+            _hdAlgorithm,
+            _options,
+            new CreateWalletRequest());
+
+        // Assert
+        result
+            .Result.Should().BeOfType<CreatedResult>()
+            .Which.Value.Should().BeOfType<CreateWalletResponse>()
+            .Which.WalletId.Should().NotBeEmpty();
+
+        var wallet = await _unitOfWork.WalletRepository.GetWallet(subject);
+        wallet.Should().NotBeNull();
+        wallet!.PrivateKey.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task Verify_OnlySingleAllowedPerSubject()
+    {
+        // Arrange
+        var subject = _fixture.Create<string>();
+        var controller = new WalletController()
+        {
+            ControllerContext = CreateContextWithUser(subject)
+        };
+
+        var firstCreateResult = await controller.CreateWallet(
+            _unitOfWork,
+            _hdAlgorithm,
+            _options,
+            new CreateWalletRequest());
+
+        firstCreateResult.Result.Should().BeOfType<CreatedResult>();
+
+        // Act
+        var secondCreateResult = await controller.CreateWallet(
+            _unitOfWork,
+            _hdAlgorithm,
+            _options,
+            new CreateWalletRequest());
+
+        // Assert
+        secondCreateResult.Result.Should().BeOfType<BadRequestObjectResult>()
+            .Which.Value.Should().Be("Wallet already exists.");
+    }
+
+    [Fact]
+    public async Task Verify_GetWallets()
+    {
+        // Arrange
+        var subject = _fixture.Create<string>();
+        var controller = new WalletController()
+        {
+            ControllerContext = CreateContextWithUser(subject)
+        };
+
+        var createResult = await controller.CreateWallet(
+            _unitOfWork,
+            _hdAlgorithm,
+            _options,
+            new CreateWalletRequest());
+
+        var response = createResult.Result.Should().BeOfType<CreatedResult>()
+            .Which.Value.Should().BeOfType<CreateWalletResponse>().Which;
+
+        // Act
+        var getResult = await controller.GetWallets(_unitOfWork);
+
+        // Assert
+        getResult.Result.Should().BeOfType<OkObjectResult>()
+            .Which.Value.Should().BeOfType<ResultList<WalletRecord>>()
+            .Which.Result.Should().ContainSingle()
+            .Which.Id.Should().Be(response!.WalletId);
+    }
+
+    [Fact]
+    public async Task Verify_GetWallets_NotFound()
+    {
+        // Arrange
+        var subject = _fixture.Create<string>();
+        var controller = new WalletController()
+        {
+            ControllerContext = CreateContextWithUser(subject)
+        };
+
+        // Act
+        var getResult = await controller.GetWallets(_unitOfWork);
+
+        // Assert
+        getResult.Result.Should().BeOfType<OkObjectResult>()
+          .Which.Value.Should().BeOfType<ResultList<WalletRecord>>()
+          .Which.Result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Verify_GetWallets_Unauthorized()
+    {
+        // Arrange
+        var controller = new WalletController();
+
+        // Act
+        var getResult = await controller.GetWallets(_unitOfWork);
+
+        // Assert
+        getResult.Result.Should().BeOfType<UnauthorizedResult>();
+    }
+
+    [Fact]
+    public async Task Verify_GetWallet_WithWalletId()
+    {
+        // Arrange
+        var subject = _fixture.Create<string>();
+        var controller = new WalletController()
+        {
+            ControllerContext = CreateContextWithUser(subject)
+        };
+
+        var createResult = await controller.CreateWallet(
+            _unitOfWork,
+            _hdAlgorithm,
+            _options,
+            new CreateWalletRequest());
+
+        var createdResponse = createResult.Result.Should().BeOfType<CreatedResult>()
+            .Which.Value.Should().BeOfType<CreateWalletResponse>().Which;
+
+        // Act
+        var getResult = await controller.GetWallet(_unitOfWork, createdResponse.WalletId);
+
+        // Assert
+        getResult.Result.Should().BeOfType<OkObjectResult>()
+            .Which.Value.Should().BeOfType<WalletRecord>()
+            .Which.Id.Should().Be(createdResponse.WalletId);
+    }
+
+    [Fact]
+    public async Task Verify_GetWalletWithId_Unauthorized()
+    {
+        // Arrange
+        var controller = new WalletController();
+
+        // Act
+        var getResult = await controller.GetWallet(_unitOfWork, Guid.NewGuid());
+
+        // Assert
+        getResult.Result.Should().BeOfType<UnauthorizedResult>();
+    }
+
+    [Fact]
+    public async Task Verify_GetWalletWithId_NotFound()
+    {
+        // Arrange
+        var subject = _fixture.Create<string>();
+        var controller = new WalletController()
+        {
+            ControllerContext = CreateContextWithUser(subject)
+        };
+
+        // Act
+        var getResult = await controller.GetWallet(_unitOfWork, Guid.NewGuid());
+
+        // Assert
+        getResult.Result.Should().BeOfType<NotFoundResult>();
+    }
+
+    [Fact]
+    public async Task Verify_GetWalletWithId_ForDifferentUser_NotFound()
+    {
+        // Arrange
+        var subject1 = _fixture.Create<string>();
+        var controller1 = new WalletController()
+        {
+            ControllerContext = CreateContextWithUser(subject1)
+        };
+
+
+        var subject2 = _fixture.Create<string>();
+        var controller2 = new WalletController()
+        {
+            ControllerContext = CreateContextWithUser(subject2)
+        };
+
+        var createResult = await controller1.CreateWallet(
+            _unitOfWork,
+            _hdAlgorithm,
+            _options,
+            new CreateWalletRequest());
+
+        var createdResponse = createResult.Result.Should().BeOfType<CreatedResult>()
+            .Which.Value.Should().BeOfType<CreateWalletResponse>().Which;
+
+        // Act
+        var getResult = await controller1.GetWallet(_unitOfWork, createdResponse.WalletId);
+
+        // Assert
+        getResult.Result.Should().BeOfType<OkObjectResult>()
+            .Which.Value.Should().BeOfType<WalletRecord>()
+            .Which.Id.Should().Be(createdResponse.WalletId);
+
+        // Act
+        var getResultForDifferentUser = await controller2.GetWallet(_unitOfWork, createdResponse.WalletId);
+
+        // Assert
+        getResultForDifferentUser.Result.Should().BeOfType<NotFoundResult>();
+    }
+
+    [Fact]
+    public async Task Verify_CreateWalletEndpoint_Unauthorized()
+    {
+        // Arrange
+        var controller = new WalletController();
+
+        // Act
+        var result = await controller.CreateWalletEndpoint(
+            _unitOfWork,
+            _options,
+            Guid.NewGuid());
+
+        // Assert
+        result.Result.Should().BeOfType<UnauthorizedResult>();
+    }
+
+    [Fact]
+    public async Task Verify_CreateWalletEndpoint_WalletNotFound()
+    {
+        // Arrange
+        var subject = _fixture.Create<string>();
+        var controller = new WalletController()
+        {
+            ControllerContext = CreateContextWithUser(subject)
+        };
+
+        // Act
+        var result = await controller.CreateWalletEndpoint(
+            _unitOfWork,
+            _options,
+            Guid.NewGuid());
+
+        // Assert
+        result.Result.Should().BeOfType<NotFoundResult>();
+    }
+
+    [Fact]
+    public async Task Verify_CreateWalletEndpoint_Success()
+    {
+        // Arrange
+        var subject = _fixture.Create<string>();
+        var controller = new WalletController()
+        {
+            ControllerContext = CreateContextWithUser(subject)
+        };
+
+        var createResult = await controller.CreateWallet(
+              _unitOfWork,
+              _hdAlgorithm,
+            _options,
+              new CreateWalletRequest());
+
+        var createdResponse = createResult.Result.Should().BeOfType<CreatedResult>()
+            .Which.Value.Should().BeOfType<CreateWalletResponse>().Which;
+
+        // Act
+        var result = await controller.CreateWalletEndpoint(
+            _unitOfWork,
+            _options,
+            createdResponse.WalletId
+            );
+
+        // Assert
+        var response = result.Result.Should().BeOfType<CreatedResult>()
+            .Which.Value.Should().BeOfType<CreateWalletEndpointResponse>().Which;
+
+        response.WalletReference.Version.Should().Be(1);
+        response.WalletReference.Endpoint.Should().BeEquivalentTo(new Uri(_options.Value.EndpointAddress, "/v1/slices"));
+        response.WalletReference.PublicKey.Should().NotBeNull();
+
+        var endpointsFound = await _unitOfWork.WalletRepository.GetWalletEndpoint(response.WalletReference.PublicKey);
+        endpointsFound.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task Verify_CreateExternalEndpoint_Unauthorized()
+    {
+        // Arrange
+        var controller = new WalletController();
+
+        // Act
+        var result = await controller.CreateExternalEndpoint(
+            _unitOfWork,
+            new CreateExternalEndpointRequest()
+            {
+                TextReference = _fixture.Create<string>(),
+                WalletReference = new WalletEndpointReference()
+                {
+                    PublicKey = _hdAlgorithm.GenerateNewPrivateKey().Neuter(),
+                    Version = 1,
+                    Endpoint = new Uri("https://example.com")
+                }
+            });
+
+        // Assert
+        result.Result.Should().BeOfType<UnauthorizedResult>();
+    }
+
+    [Fact]
+    public async Task Verify_CreateExternalEndpoint_Success()
+    {
+        // Arrange
+        var subject = _fixture.Create<string>();
+        var controller = new WalletController()
+        {
+            ControllerContext = CreateContextWithUser(subject)
+        };
+
+        // Act
+        var result = await controller.CreateExternalEndpoint(
+            _unitOfWork,
+            new CreateExternalEndpointRequest()
+            {
+                TextReference = _fixture.Create<string>(),
+                WalletReference = new WalletEndpointReference()
+                {
+                    PublicKey = _hdAlgorithm.GenerateNewPrivateKey().Neuter(),
+                    Version = 1,
+                    Endpoint = new Uri("https://example.com")
+                }
+            });
+
+        // Assert
+        var response = result.Result.Should().BeOfType<CreatedResult>()
+            .Which.Value.Should().BeOfType<CreateExternalEndpointResponse>().Which;
+
+        response.ReceiverId.Should().NotBeEmpty();
+
+        var endpointFound = await _unitOfWork.WalletRepository.GetExternalEndpoint(response.ReceiverId);
+        endpointFound.Should().NotBeNull();
+    }
+
+    private static ControllerContext CreateContextWithUser(string subject)
+    {
+        return new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext
+            {
+                User = new ClaimsPrincipal(new ClaimsIdentity(new System.Security.Claims.Claim[]
+                {
+                     new(ClaimTypes.NameIdentifier, subject),
+                })),
+            }
+        };
+    }
+}

--- a/src/ProjectOrigin.WalletSystem.IntegrationTests/TestClassFixtures/TestServerFixture.cs
+++ b/src/ProjectOrigin.WalletSystem.IntegrationTests/TestClassFixtures/TestServerFixture.cs
@@ -122,6 +122,8 @@ namespace ProjectOrigin.WalletSystem.IntegrationTests.TestClassFixtures
 
         public HttpClient CreateHttpClient()
         {
+            EnsureServer();
+
             var client = _server!.CreateClient();
             return client;
         }

--- a/src/ProjectOrigin.WalletSystem.IntegrationTests/TestExtensions/IHDAlgorithmExtensionsTests.cs
+++ b/src/ProjectOrigin.WalletSystem.IntegrationTests/TestExtensions/IHDAlgorithmExtensionsTests.cs
@@ -1,0 +1,42 @@
+using FluentAssertions;
+using ProjectOrigin.HierarchicalDeterministicKeys.Implementations;
+using ProjectOrigin.HierarchicalDeterministicKeys.Interfaces;
+using ProjectOrigin.WalletSystem.Server.Extensions;
+using Xunit;
+
+namespace ProjectOrigin.WalletSystem.IntegrationTests.Extensions;
+
+
+public class IHDAlgorithmExtensionsTests
+{
+    [Fact]
+    public void Valid_PrivateKey()
+    {
+        // Arrange
+        var hdAlgorithm = new Secp256k1Algorithm();
+        var privateKeyBytes = hdAlgorithm.GenerateNewPrivateKey().Export().ToArray();
+
+        // Act
+        var result = hdAlgorithm.TryImportHDPrivateKey(privateKeyBytes, out var hdPrivateKey);
+
+        // Assert
+        result.Should().BeTrue();
+        hdPrivateKey.Should().NotBeNull();
+        hdPrivateKey.Should().BeAssignableTo<IHDPrivateKey>();
+    }
+
+    [Fact]
+    public void Invalid_PrivateKey()
+    {
+        // Arrange
+        var hdAlgorithm = new Secp256k1Algorithm();
+        var privateKeyBytes = new byte[] { 0x00, 0x01, 0x02, 0x03 };
+
+        // Act
+        var result = hdAlgorithm.TryImportHDPrivateKey(privateKeyBytes, out var hdPrivateKey);
+
+        // Assert
+        result.Should().BeFalse();
+        hdPrivateKey.Should().BeNull();
+    }
+}

--- a/src/ProjectOrigin.WalletSystem.IntegrationTests/TestExtensions/IHDAlgorithmExtensionsTests.cs
+++ b/src/ProjectOrigin.WalletSystem.IntegrationTests/TestExtensions/IHDAlgorithmExtensionsTests.cs
@@ -39,4 +39,36 @@ public class IHDAlgorithmExtensionsTests
         result.Should().BeFalse();
         hdPrivateKey.Should().BeNull();
     }
+
+
+    [Fact]
+    public void Valid_PublicKey()
+    {
+        // Arrange
+        var hdAlgorithm = new Secp256k1Algorithm();
+        var privateKeyBytes = hdAlgorithm.GenerateNewPrivateKey().Neuter().Export().ToArray();
+
+        // Act
+        var result = hdAlgorithm.TryImportHDPublicKey(privateKeyBytes, out var hdPrivateKey);
+
+        // Assert
+        result.Should().BeTrue();
+        hdPrivateKey.Should().NotBeNull();
+        hdPrivateKey.Should().BeAssignableTo<IHDPublicKey>();
+    }
+
+    [Fact]
+    public void Invalid_PublicKey()
+    {
+        // Arrange
+        var hdAlgorithm = new Secp256k1Algorithm();
+        var privateKeyBytes = new byte[] { 0x00, 0x01, 0x02, 0x03 };
+
+        // Act
+        var result = hdAlgorithm.TryImportHDPublicKey(privateKeyBytes, out var hdPrivateKey);
+
+        // Assert
+        result.Should().BeFalse();
+        hdPrivateKey.Should().BeNull();
+    }
 }

--- a/src/ProjectOrigin.WalletSystem.Server/Activities/SendInformationToReceiverWalletActivity.cs
+++ b/src/ProjectOrigin.WalletSystem.Server/Activities/SendInformationToReceiverWalletActivity.cs
@@ -40,7 +40,7 @@ public class SendInformationToReceiverWalletActivity : IExecuteActivity<SendInfo
         var newSlice = await _unitOfWork.CertificateRepository.GetTransferredSlice(context.Arguments.SliceId);
         var externalEndpoint = await _unitOfWork.WalletRepository.GetExternalEndpoint(context.Arguments.ExternalEndpointId);
 
-        if (_walletSystemOptions.Value.EndpointAddress == externalEndpoint.Endpoint)
+        if (_walletSystemOptions.Value.EndpointAddress.Equals(externalEndpoint.Endpoint))
         {
             return await InsertIntoLocalWallet(context, newSlice, externalEndpoint);
         }

--- a/src/ProjectOrigin.WalletSystem.Server/Extensions/IHDAlgorithmExtensions.cs
+++ b/src/ProjectOrigin.WalletSystem.Server/Extensions/IHDAlgorithmExtensions.cs
@@ -1,0 +1,21 @@
+using System;
+using ProjectOrigin.HierarchicalDeterministicKeys.Interfaces;
+
+namespace ProjectOrigin.WalletSystem.Server.Extensions;
+
+public static class IHDAlgorithmExtensions
+{
+    public static bool TryImportHDPrivateKey(this IHDAlgorithm hdAlgorithm, byte[] privateKeyBytes, out IHDPrivateKey hdPrivateKey)
+    {
+        try
+        {
+            hdPrivateKey = hdAlgorithm.ImportHDPrivateKey(privateKeyBytes);
+            return true;
+        }
+        catch (Exception)
+        {
+            hdPrivateKey = null!;
+            return false;
+        }
+    }
+}

--- a/src/ProjectOrigin.WalletSystem.Server/Extensions/IHDAlgorithmExtensions.cs
+++ b/src/ProjectOrigin.WalletSystem.Server/Extensions/IHDAlgorithmExtensions.cs
@@ -18,4 +18,18 @@ public static class IHDAlgorithmExtensions
             return false;
         }
     }
+
+    public static bool TryImportHDPublicKey(this IHDAlgorithm hdAlgorithm, byte[] publicKeyBytes, out IHDPublicKey hdPublicKey)
+    {
+        try
+        {
+            hdPublicKey = hdAlgorithm.ImportHDPublicKey(publicKeyBytes);
+            return true;
+        }
+        catch (Exception)
+        {
+            hdPublicKey = null!;
+            return false;
+        }
+    }
 }

--- a/src/ProjectOrigin.WalletSystem.Server/Options/ServiceOptions.cs
+++ b/src/ProjectOrigin.WalletSystem.Server/Options/ServiceOptions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.ComponentModel.DataAnnotations;
 
 namespace ProjectOrigin.WalletSystem.Server.Options;
@@ -5,5 +6,5 @@ namespace ProjectOrigin.WalletSystem.Server.Options;
 public class ServiceOptions
 {
     [Required(AllowEmptyStrings = false)]
-    public string EndpointAddress { get; set; } = string.Empty;
+    public required Uri EndpointAddress { get; set; }
 }

--- a/src/ProjectOrigin.WalletSystem.Server/Repositories/IWalletRepository.cs
+++ b/src/ProjectOrigin.WalletSystem.Server/Repositories/IWalletRepository.cs
@@ -8,7 +8,7 @@ namespace ProjectOrigin.WalletSystem.Server.Repositories;
 public interface IWalletRepository
 {
     Task<int> Create(Wallet wallet);
-    Task<Wallet> GetWallet(Guid walletId);
+    Task<Wallet?> GetWallet(Guid walletId);
     Task<Wallet?> GetWallet(string owner);
 
     Task<WalletEndpoint> CreateWalletEndpoint(Guid walletId);

--- a/src/ProjectOrigin.WalletSystem.Server/Repositories/WalletRepository.cs
+++ b/src/ProjectOrigin.WalletSystem.Server/Repositories/WalletRepository.cs
@@ -52,7 +52,7 @@ public class WalletRepository : IWalletRepository
     {
         var position = await GetNextNumberForId(walletId);
 
-        var wallet = await GetWallet(walletId);
+        var wallet = await GetWallet(walletId) ?? throw new InvalidOperationException("Wallet not found");
         var key = wallet.PrivateKey.Derive(position).Neuter();
 
         var newEndpoint = new WalletEndpoint
@@ -149,7 +149,7 @@ public class WalletRepository : IWalletRepository
 
         if (endpoint is null)
         {
-            var wallet = await GetWallet(walletId);
+            var wallet = await GetWallet(walletId) ?? throw new InvalidOperationException("Wallet not found");
             var nextWalletPosition = await GetNextNumberForId(walletId);
             var publicKey = wallet.PrivateKey.Derive(nextWalletPosition).Neuter();
 

--- a/src/ProjectOrigin.WalletSystem.Server/Repositories/WalletRepository.cs
+++ b/src/ProjectOrigin.WalletSystem.Server/Repositories/WalletRepository.cs
@@ -24,9 +24,9 @@ public class WalletRepository : IWalletRepository
             wallet);
     }
 
-    public Task<Wallet> GetWallet(Guid walletId)
+    public Task<Wallet?> GetWallet(Guid walletId)
     {
-        return _connection.QuerySingleAsync<Wallet>(
+        return _connection.QuerySingleOrDefaultAsync<Wallet>(
             @"SELECT *
               FROM Wallets
               WHERE Id = @walletId",

--- a/src/ProjectOrigin.WalletSystem.Server/Serialization/IHDPublicKeyConverter.cs
+++ b/src/ProjectOrigin.WalletSystem.Server/Serialization/IHDPublicKeyConverter.cs
@@ -9,7 +9,7 @@ namespace ProjectOrigin.WalletSystem.Server.Serialization;
 
 public class IHDPublicKeyConverter : JsonConverter<IHDPublicKey>
 {
-    private IHDAlgorithm _algorithm;
+    private readonly IHDAlgorithm _algorithm;
 
     public IHDPublicKeyConverter(IHDAlgorithm algorithm)
     {

--- a/src/ProjectOrigin.WalletSystem.Server/Serialization/IHDPublicKeyConverter.cs
+++ b/src/ProjectOrigin.WalletSystem.Server/Serialization/IHDPublicKeyConverter.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.OpenApi.Models;
+using ProjectOrigin.HierarchicalDeterministicKeys.Interfaces;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace ProjectOrigin.WalletSystem.Server.Serialization;
+
+public class IHDPublicKeyConverter : JsonConverter<IHDPublicKey>
+{
+    private IHDAlgorithm _algorithm;
+
+    public IHDPublicKeyConverter(IHDAlgorithm algorithm)
+    {
+        _algorithm = algorithm;
+    }
+
+    public override IHDPublicKey? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        return _algorithm.ImportHDPublicKey(reader.GetBytesFromBase64());
+    }
+
+    public override void Write(Utf8JsonWriter writer, IHDPublicKey value, JsonSerializerOptions options)
+    {
+        writer.WriteBase64StringValue(value.Export());
+    }
+}
+
+public class IHDPublicKeySchemaFilter : ISchemaFilter
+{
+    public void Apply(OpenApiSchema schema, SchemaFilterContext context)
+    {
+        if (context.Type == typeof(IHDPublicKey))
+        {
+            schema.Type = "string";
+        }
+    }
+}

--- a/src/ProjectOrigin.WalletSystem.Server/Services/GRPC/WalletService.cs
+++ b/src/ProjectOrigin.WalletSystem.Server/Services/GRPC/WalletService.cs
@@ -21,7 +21,7 @@ namespace ProjectOrigin.WalletSystem.Server.Services.GRPC;
 [Authorize]
 public class WalletService : V1.WalletService.WalletServiceBase
 {
-    private readonly string _walletSystemAddress;
+    private readonly Uri _walletSystemAddress;
     private readonly IUnitOfWork _unitOfWork;
     private readonly IHDAlgorithm _hdAlgorithm;
     private readonly IBus _bus;
@@ -61,7 +61,7 @@ public class WalletService : V1.WalletService.WalletServiceBase
             WalletDepositEndpoint = new V1.WalletDepositEndpoint()
             {
                 Version = 1,
-                Endpoint = _walletSystemAddress,
+                Endpoint = _walletSystemAddress.ToString(),
                 PublicKey = ByteString.CopyFrom(endpoint.PublicKey.Export())
             }
         };
@@ -94,7 +94,7 @@ public class WalletService : V1.WalletService.WalletServiceBase
         var foundEndpoint = await _unitOfWork.WalletRepository.GetWalletEndpoint(ownerPublicKey);
         if (foundEndpoint is not null)
         {
-            var wallet = await _unitOfWork.WalletRepository.GetWallet(foundEndpoint.WalletId);
+            var wallet = await _unitOfWork.WalletRepository.GetWallet(foundEndpoint.WalletId) ?? throw new InvalidOperationException("Wallet not found.");
             if (wallet.Owner == subject)
             {
                 throw new RpcException(new Status(StatusCode.InvalidArgument, "Cannot create receiver deposit endpoint to self."));

--- a/src/ProjectOrigin.WalletSystem.Server/Services/REST/v1/SlicesController.cs
+++ b/src/ProjectOrigin.WalletSystem.Server/Services/REST/v1/SlicesController.cs
@@ -94,6 +94,7 @@ public record ReceiveRequest()
 
     /// <summary>
     /// The sub-position of the publicKey used on the slice on the registry.
+    /// </summary>
     public required uint Position { get; init; }
 
     /// <summary>

--- a/src/ProjectOrigin.WalletSystem.Server/Services/REST/v1/SlicesController.cs
+++ b/src/ProjectOrigin.WalletSystem.Server/Services/REST/v1/SlicesController.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using MassTransit;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using ProjectOrigin.HierarchicalDeterministicKeys.Interfaces;
+using ProjectOrigin.WalletSystem.Server.CommandHandlers;
+using ProjectOrigin.WalletSystem.Server.Database;
+using ProjectOrigin.WalletSystem.Server.Extensions;
+using ProjectOrigin.WalletSystem.Server.Models;
+
+namespace ProjectOrigin.WalletSystem.Server.Services.REST.v1;
+
+[AllowAnonymous]
+[ApiController]
+public class SlicesController : ControllerBase
+{
+    /// <summary>
+    /// Receive a certificate-slice from another wallet.
+    /// </summary>
+    /// <remarks>
+    /// This request is used to receive a certificate-slice from another wallet, which is then stored in the local wallet.
+    /// The endpoint is verified to exists within the wallet system, otherwise a 404 will be returned.
+    /// The endpoint will return 202 Accepted was initial validation has succeeded.
+    /// The certificate-slice will further verified with data from the registry in a seperate thread.
+    /// </remarks>
+    /// <param name = "unitOfWork" ></param>
+    /// <param name = "hdAlgorithm" ></param>
+    /// <param name = "bus" ></param>
+    /// <param name = "request" >Contains the data </param>
+    /// <response code="202">The slice was accepted.</response>
+    /// <response code="400">Public key could not be decoded.</response>
+    /// <response code="404">Receiver endpoint not found.</response>
+    [HttpPost]
+    [Route("v1/slices")]
+    [Produces("application/json")]
+    [ProducesResponseType(StatusCodes.Status202Accepted)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<ReceiveResponse>> ReceiveSlice(
+        [FromServices] IUnitOfWork unitOfWork,
+        [FromServices] IHDAlgorithm hdAlgorithm,
+        [FromServices] IBus bus,
+        [FromBody] ReceiveRequest request
+    )
+    {
+        if (!hdAlgorithm.TryImportHDPublicKey(request.PublicKey, out var publicKey))
+            return BadRequest("Invalid public key.");
+
+        var endpoint = await unitOfWork.WalletRepository.GetWalletEndpoint(publicKey);
+        if (endpoint == null)
+            return NotFound("Endpoint not found for public key.");
+
+        var newSliceCommand = new VerifySliceCommand
+        {
+            Id = Guid.NewGuid(),
+            WalletId = endpoint.WalletId,
+            WalletEndpointId = endpoint.Id,
+            WalletEndpointPosition = (int)request.Position,
+            Registry = request.CertificateId.Registry,
+            CertificateId = request.CertificateId.StreamId,
+            Quantity = request.Quantity,
+            RandomR = request.RandomR,
+            HashedAttributes = request.HashedAttributes.Select(x => new WalletAttribute
+            {
+                CertificateId = request.CertificateId.StreamId,
+                RegistryName = request.CertificateId.Registry,
+                Key = x.Key,
+                Value = x.Value,
+                Salt = x.Salt
+            }).ToList()
+        };
+
+        await bus.Publish(newSliceCommand);
+
+        return Accepted(new ReceiveResponse());
+    }
+}
+
+#region Records
+
+/// <summary>
+/// Request to receive a certificate-slice from another wallet.
+/// </summary>
+public record ReceiveRequest
+{
+    /// <summary>
+    /// The public key of the receiving wallet.
+    /// </summary>
+    public required byte[] PublicKey { get; init; }
+
+    /// <summary>
+    /// The sub-position of the publicKey used on the slice on the registry.
+    public required uint Position { get; init; }
+
+    /// <summary>
+    /// The id of the certificate.
+    /// </summary>
+    public required FederatedStreamId CertificateId { get; init; }
+
+    /// <summary>
+    /// The quantity of the slice.
+    /// </summary>
+    public required uint Quantity { get; init; }
+
+    /// <summary>
+    /// The random R used to generate the pedersen commitment with the quantitiy.
+    /// </summary>
+    public required byte[] RandomR { get; init; }
+
+    /// <summary>
+    /// List of hashed attributes, their values and salts so the receiver can access the data.
+    /// </summary>
+    public required IEnumerable<HashedAttribute> HashedAttributes { get; init; }
+}
+
+/// <summary>
+/// Hashed attribute with salt.
+/// </summary>
+public record HashedAttribute
+{
+
+    /// <summary>
+    /// The key of the attribute.
+    /// </summary>
+    public required string Key { get; init; }
+
+    /// <summary>
+    /// The value of the attribute.
+    /// </summary>
+    public required string Value { get; init; }
+
+    /// <summary>
+    /// The salt used to hash the attribute.
+    /// </summary>
+    public required byte[] Salt { get; init; }
+}
+
+/// <summary>
+/// Response to receive a certificate-slice from another wallet.
+/// </summary>
+public record ReceiveResponse { }
+
+#endregion

--- a/src/ProjectOrigin.WalletSystem.Server/Services/REST/v1/SlicesController.cs
+++ b/src/ProjectOrigin.WalletSystem.Server/Services/REST/v1/SlicesController.cs
@@ -85,7 +85,7 @@ public class SlicesController : ControllerBase
 /// <summary>
 /// Request to receive a certificate-slice from another wallet.
 /// </summary>
-public record ReceiveRequest
+public record ReceiveRequest()
 {
     /// <summary>
     /// The public key of the receiving wallet.
@@ -120,7 +120,7 @@ public record ReceiveRequest
 /// <summary>
 /// Hashed attribute with salt.
 /// </summary>
-public record HashedAttribute
+public record HashedAttribute()
 {
 
     /// <summary>
@@ -142,6 +142,6 @@ public record HashedAttribute
 /// <summary>
 /// Response to receive a certificate-slice from another wallet.
 /// </summary>
-public record ReceiveResponse { }
+public record ReceiveResponse() { }
 
 #endregion

--- a/src/ProjectOrigin.WalletSystem.Server/Services/REST/v1/WalletController.cs
+++ b/src/ProjectOrigin.WalletSystem.Server/Services/REST/v1/WalletController.cs
@@ -229,7 +229,7 @@ public class WalletController : ControllerBase
 /// <summary>
 /// A wallet record
 /// </summary>
-public record WalletRecord
+public record WalletRecord()
 {
     public required Guid Id { get; init; }
     public required IHDPublicKey PublicKey { get; init; }
@@ -260,7 +260,7 @@ public record CreateWalletResponse()
 /// <summary>
 /// Response to create a new wallet endpoint on the users wallet.
 /// </summary>
-public record CreateWalletEndpointResponse
+public record CreateWalletEndpointResponse()
 {
     /// <summary>
     /// Reference object to the wallet endpoint created.
@@ -272,7 +272,7 @@ public record CreateWalletEndpointResponse
 /// <summary>
 /// Request to create a new external endpoint.
 /// </summary>
-public record CreateExternalEndpointRequest
+public record CreateExternalEndpointRequest()
 {
     /// <summary>
     /// The wallet reference to the wallet, one wants to create a link to.
@@ -288,7 +288,7 @@ public record CreateExternalEndpointRequest
 /// <summary>
 /// Response to create a new external endpoint.
 /// </summary>
-public record CreateExternalEndpointResponse
+public record CreateExternalEndpointResponse()
 {
     /// <summary>
     /// The ID of the created external endpoint.
@@ -296,7 +296,7 @@ public record CreateExternalEndpointResponse
     public required Guid ReceiverId { get; init; }
 }
 
-public record WalletEndpointReference
+public record WalletEndpointReference()
 {
     /// <summary>
     /// The version of the ReceiveSlice API.

--- a/src/ProjectOrigin.WalletSystem.Server/Services/REST/v1/WalletController.cs
+++ b/src/ProjectOrigin.WalletSystem.Server/Services/REST/v1/WalletController.cs
@@ -1,0 +1,317 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using ProjectOrigin.HierarchicalDeterministicKeys.Interfaces;
+using ProjectOrigin.WalletSystem.Server.Database;
+using ProjectOrigin.WalletSystem.Server.Extensions;
+using ProjectOrigin.WalletSystem.Server.Models;
+using ProjectOrigin.WalletSystem.Server.Options;
+
+namespace ProjectOrigin.WalletSystem.Server.Services.REST.v1;
+
+[Authorize]
+[ApiController]
+public class WalletController : ControllerBase
+{
+    /// <summary>
+    /// Creates a new wallet for the user.
+    /// </summary>
+    /// <remarks>
+    /// Currently, only **one wallet** per user is supported.
+    /// The wallet is created with a private key, which is used to generate sub-public-keys for each certificate-slice.
+    /// The private key can be provided, but it is optional, if omittted a random one is generated.
+    /// </remarks>
+    /// <param name = "unitOfWork" ></param>
+    /// <param name = "hdAlgorithm" ></param>
+    /// <param name = "serviceOptions" ></param>
+    /// <param name = "request" > The private key to import. If not provided, a new private key will be generated.</param>
+    /// <response code="201">The wallet was created.</response>
+    /// <response code="400">If private key is invalid or if wallet for user already exists.</response>
+    /// <response code="401">If the user is not authenticated.</response>
+    [HttpPost]
+    [Route("v1/wallets")]
+    [Produces("application/json")]
+    [ProducesResponseType(StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(void), StatusCodes.Status401Unauthorized)]
+    public async Task<ActionResult<CreateWalletResponse>> CreateWallet(
+        [FromServices] IUnitOfWork unitOfWork,
+        [FromServices] IHDAlgorithm hdAlgorithm,
+        [FromServices] IOptions<ServiceOptions> serviceOptions,
+        [FromBody] CreateWalletRequest request
+    )
+    {
+        if (!User.TryGetSubject(out var subject)) return Unauthorized();
+
+        IHDPrivateKey hdPrivateKey;
+
+        if (request.PrivateKey is not null)
+        {
+            if (!hdAlgorithm.TryImportHDPrivateKey(request.PrivateKey, out hdPrivateKey))
+                return BadRequest("Invalid private key.");
+        }
+        else
+            hdPrivateKey = hdAlgorithm.GenerateNewPrivateKey();
+
+        try
+        {
+            var newWallet = new Wallet
+            {
+                Id = Guid.NewGuid(),
+                Owner = subject,
+                PrivateKey = hdPrivateKey
+            };
+
+            await unitOfWork.WalletRepository.Create(newWallet);
+
+            unitOfWork.Commit();
+
+            return Created(new Uri(serviceOptions.Value.EndpointAddress, $"/v1/wallets/{newWallet.Id}"), new CreateWalletResponse
+            {
+                WalletId = newWallet.Id
+            });
+        }
+        catch (Exception ex) when (ex.Message.Contains("duplicate key value violates unique constraint"))
+        {
+            return BadRequest("Wallet already exists.");
+        }
+    }
+
+    /// <summary>
+    /// Gets all wallets for the user.
+    /// </summary>
+    /// <param name="unitOfWork"></param>
+    /// <response code="200">The wallets were found.</response>
+    /// <response code="401">If the user is not authenticated.</response>
+    [HttpGet]
+    [Route("v1/wallets")]
+    [Produces("application/json")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(void), StatusCodes.Status401Unauthorized)]
+    public async Task<ActionResult<ResultList<WalletRecord>>> GetWallets(
+        [FromServices] IUnitOfWork unitOfWork
+    )
+    {
+        if (!User.TryGetSubject(out var subject)) return Unauthorized();
+
+        var wallet = await unitOfWork.WalletRepository.GetWallet(subject);
+
+        var list = new List<WalletRecord>();
+        if (wallet is not null)
+            list.Add(new WalletRecord
+            {
+                Id = wallet.Id,
+                PublicKey = wallet.PrivateKey.Neuter(),
+            });
+
+        return Ok(new ResultList<WalletRecord>
+        {
+            Result = list,
+        });
+    }
+
+    /// <summary>
+    /// Gets a specific wallet for the user.
+    /// </summary>
+    /// <param name="unitOfWork"></param>
+    /// <param name="walletId">The ID of the wallet to get.</param>
+    /// <response code="200">The wallet was found.</response>
+    /// <response code="401">If the user is not authenticated.</response>
+    /// <response code="404">If the wallet specified is not found for the user.</response>
+    [HttpGet]
+    [Route("v1/wallets/{walletId}")]
+    [Produces("application/json")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(void), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(void), StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<WalletRecord>> GetWallet(
+        [FromServices] IUnitOfWork unitOfWork,
+        [FromRoute] Guid walletId
+    )
+    {
+        if (!User.TryGetSubject(out var subject)) return Unauthorized();
+
+        var wallet = await unitOfWork.WalletRepository.GetWallet(walletId);
+
+        if (wallet is null || wallet.Owner != subject) return NotFound();
+
+        return Ok(new WalletRecord
+        {
+            Id = wallet.Id,
+            PublicKey = wallet.PrivateKey.Neuter(),
+        });
+    }
+
+    /// <summary>
+    /// Creates a new wallet endpoint on the users wallet, which can be sent to other services to receive certificate-slices.
+    /// </summary>
+    /// <param name = "unitOfWork" ></param>
+    /// <param name = "serviceOptions" ></param>
+    /// <param name = "walletId" > The ID of the wallet to create the endpoint on.</param>
+    /// <response code="201">The wallet endpoint was created.</response>
+    /// <response code="401">If the user is not authenticated.</response>
+    /// <response code="404">If the wallet specified is not found for the user.</response>
+    [HttpPost]
+    [Route("v1/wallets/{walletId}/endpoints")]
+    [Produces("application/json")]
+    [ProducesResponseType(StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(void), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(void), StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<CreateWalletEndpointResponse>> CreateWalletEndpoint(
+        [FromServices] IUnitOfWork unitOfWork,
+        [FromServices] IOptions<ServiceOptions> serviceOptions,
+        [FromRoute] Guid walletId
+    )
+    {
+        if (!User.TryGetSubject(out var subject)) return Unauthorized();
+
+        var wallet = await unitOfWork.WalletRepository.GetWallet(walletId);
+
+        if (wallet is null || wallet.Owner != subject) return NotFound();
+
+        var walletEndpoint = await unitOfWork.WalletRepository.CreateWalletEndpoint(wallet.Id);
+
+        unitOfWork.Commit();
+
+        return Created(null as string, new CreateWalletEndpointResponse
+        {
+            WalletReference = new WalletEndpointReference
+            {
+                Version = 1,
+                Endpoint = new Uri(serviceOptions.Value.EndpointAddress, $"/v1/slices"),
+                PublicKey = walletEndpoint.PublicKey
+            }
+        });
+
+    }
+
+    /// <summary>
+    /// Creates a new external endpoint for the user, which can user can use to send certficates to the other wallet.
+    /// </summary>
+    /// <param name="unitOfWork"></param>
+    /// <param name="request">The request to create the external endpoint.</param>
+    /// <response code="201">The external endpoint was created.</response>
+    /// <response code="401">If the user is not authenticated.</response>
+    [HttpPost]
+    [Route("v1/external-endpoints")]
+    [Produces("application/json")]
+    [ProducesResponseType(StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(void), StatusCodes.Status401Unauthorized)]
+    public async Task<ActionResult<CreateExternalEndpointResponse>> CreateExternalEndpoint(
+        [FromServices] IUnitOfWork unitOfWork,
+        [FromBody] CreateExternalEndpointRequest request
+    )
+    {
+        if (!User.TryGetSubject(out var subject)) return Unauthorized();
+
+        var externalEndpoint = await unitOfWork.WalletRepository.CreateExternalEndpoint(
+            subject,
+            request.WalletReference.PublicKey,
+            request.TextReference,
+            request.WalletReference.Endpoint.ToString());
+
+        unitOfWork.Commit();
+
+        return Created(null as string, new CreateExternalEndpointResponse
+        {
+            ReceiverId = externalEndpoint.Id
+        });
+    }
+
+}
+
+#region Records
+
+/// <summary>
+/// A wallet record
+/// </summary>
+public record WalletRecord
+{
+    public required Guid Id { get; init; }
+    public required IHDPublicKey PublicKey { get; init; }
+}
+
+/// <summary>
+/// Request to create a new wallet.
+/// </summary>
+public record CreateWalletRequest()
+{
+    /// <summary>
+    /// The private key to import. If not provided, a private key will be generated.
+    /// </summary>
+    public byte[]? PrivateKey { get; init; }
+}
+
+/// <summary>
+/// Response to create a new wallet.
+/// </summary>
+public record CreateWalletResponse()
+{
+    /// <summary>
+    /// The ID of the created wallet.
+    /// </summary>
+    public Guid WalletId { get; init; }
+}
+
+/// <summary>
+/// Response to create a new wallet endpoint on the users wallet.
+/// </summary>
+public record CreateWalletEndpointResponse
+{
+    /// <summary>
+    /// Reference object to the wallet endpoint created.
+    /// Contains the necessary information to send to another wallet to create a link so certificates can be transferred.
+    /// </summary>
+    public required WalletEndpointReference WalletReference { get; init; }
+}
+
+/// <summary>
+/// Request to create a new external endpoint.
+/// </summary>
+public record CreateExternalEndpointRequest
+{
+    /// <summary>
+    /// The wallet reference to the wallet, one wants to create a link to.
+    /// </summary>
+    public required WalletEndpointReference WalletReference { get; init; }
+
+    /// <summary>
+    /// The text reference for the wallet, one wants to create a link to.
+    /// </summary>
+    public required string TextReference { get; init; }
+}
+
+/// <summary>
+/// Response to create a new external endpoint.
+/// </summary>
+public record CreateExternalEndpointResponse
+{
+    /// <summary>
+    /// The ID of the created external endpoint.
+    /// </summary>
+    public required Guid ReceiverId { get; init; }
+}
+
+public record WalletEndpointReference
+{
+    /// <summary>
+    /// The version of the ReceiveSlice API.
+    /// </summary>
+    public required int Version { get; init; } // The version of the Wallet protobuf API.
+
+    /// <summary>
+    /// The url endpoint of where the wallet is hosted.
+    /// </summary>
+    public required Uri Endpoint { get; init; }
+
+    /// <summary>
+    /// The public key used to generate sub-public-keys for each slice.
+    /// </summary>
+    public required IHDPublicKey PublicKey { get; init; }
+}
+
+#endregion


### PR DESCRIPTION
# Breaking change in helm chart

When updating one must move a variable in the helm chart

```yaml
rest:
    basePath: /api
```

has moved to 

```yaml
config:
    basePath: /api
```

## feature

Added REST apis to enable creation and get of an owners wallet, and creation of wallet-endpoints and external-endpoints.