### PR TITLE
Fix ClaimViewModel ID property name and update mapping

### DIFF
--- a/src/ProjectOrigin.WalletSystem.IntegrationTests/ApiTests/ApiTests.can_query_claims.verified.txt
+++ b/src/ProjectOrigin.WalletSystem.IntegrationTests/ApiTests/ApiTests.can_query_claims.verified.txt
@@ -1,12 +1,12 @@
 ﻿{
   result: [
     {
-      claimId: Guid_Empty,
+      claimId: Guid_1,
       quantity: 42,
       productionCertificate: {
         federatedStreamId: {
-          registry: Guid_1,
-          streamId: Guid_2
+          registry: Guid_2,
+          streamId: Guid_3
         },
         start: 1672574400,
         end: 1672578000,
@@ -19,8 +19,8 @@
       },
       consumptionCertificate: {
         federatedStreamId: {
-          registry: Guid_1,
-          streamId: Guid_3
+          registry: Guid_2,
+          streamId: Guid_4
         },
         start: 1672574400,
         end: 1672578000,

--- a/src/ProjectOrigin.WalletSystem.IntegrationTests/Repositories/ClaimRepositoryTests.cs
+++ b/src/ProjectOrigin.WalletSystem.IntegrationTests/Repositories/ClaimRepositoryTests.cs
@@ -95,6 +95,7 @@ public class ClaimRepositoryTests : AbstractRepositoryTests
         result.Items.Should().NotBeNull();
         result.Items.Should().HaveCount(48);
         result.Items.Sum(x => x.Quantity).Should().Be(16500);
+        result.Items.First().ClaimId.Should().NotBe(Guid.Empty);
     }
 
     [Fact]

--- a/src/ProjectOrigin.WalletSystem.Server/Services/REST/v1/MappingExtensions.cs
+++ b/src/ProjectOrigin.WalletSystem.Server/Services/REST/v1/MappingExtensions.cs
@@ -40,7 +40,7 @@ public static class MappingExtensions
     public static Claim MapToV1(this ClaimViewModel vm) =>
         new()
         {
-            ClaimId = vm.Id,
+            ClaimId = vm.ClaimId,
             Quantity = vm.Quantity,
             ProductionCertificate = new ClaimedCertificate
             {

--- a/src/ProjectOrigin.WalletSystem.Server/ViewModels/ClaimViewModel.cs
+++ b/src/ProjectOrigin.WalletSystem.Server/ViewModels/ClaimViewModel.cs
@@ -7,7 +7,7 @@ namespace ProjectOrigin.WalletSystem.Server.ViewModels;
 
 public record ClaimViewModel
 {
-    public required Guid Id { get; init; }
+    public required Guid ClaimId { get; init; }
     public required uint Quantity { get; init; }
 
     public required string ProductionRegistryName { get; init; }
@@ -28,7 +28,7 @@ public record ClaimViewModel
     {
         return new V1.Claim
         {
-            ClaimId = new Common.V1.Uuid { Value = Id.ToString() },
+            ClaimId = new Common.V1.Uuid { Value = ClaimId.ToString() },
             Quantity = Quantity,
             ProductionCertificate = new V1.Claim.Types.ClaimCertificateInfo
             {


### PR DESCRIPTION
This pull request fixes the issue with the ClaimViewModel ID property name and updates the mapping accordingly. The ClaimViewModel now uses the correct property name "ClaimId" instead of "Id". This ensures that the ClaimId is properly assigned and used throughout the codebase.