### PR TITLE
Allow multiple wallets per subject

### DIFF
--- a/src/ProjectOrigin.WalletSystem.IntegrationTests/ApiTests/ApiTests.open_api_specification_not_changed.verified.txt
+++ b/src/ProjectOrigin.WalletSystem.IntegrationTests/ApiTests/ApiTests.open_api_specification_not_changed.verified.txt
@@ -13,7 +13,7 @@
         "summary": "Gets all certificates in the wallet that are <b>available</b> for use.",
         "parameters": [
           {
-            "name": "start",
+            "name": "Start",
             "in": "query",
             "description": "The start of the time range in Unix time in seconds.",
             "schema": {
@@ -22,7 +22,7 @@
             }
           },
           {
-            "name": "end",
+            "name": "End",
             "in": "query",
             "description": "The end of the time range in Unix time in seconds.",
             "schema": {
@@ -31,7 +31,7 @@
             }
           },
           {
-            "name": "type",
+            "name": "Type",
             "in": "query",
             "description": "Filter the type of certificates to return.",
             "schema": {
@@ -39,7 +39,7 @@
             }
           },
           {
-            "name": "limit",
+            "name": "Limit",
             "in": "query",
             "description": "The number of items to return.",
             "schema": {
@@ -48,7 +48,7 @@
             }
           },
           {
-            "name": "skip",
+            "name": "Skip",
             "in": "query",
             "description": "The number of items to skip.",
             "schema": {
@@ -83,15 +83,15 @@
         "summary": "Returns aggregates certificates that are <b>available</b> to use, based on the specified time zone and time range.",
         "parameters": [
           {
-            "name": "timeAggregate",
+            "name": "TimeAggregate",
             "in": "query",
-            "description": "The size of each bucket in the aggregation",
+            "description": "The size of each bucket in the aggregation.",
             "schema": {
               "$ref": "#/components/schemas/TimeAggregate"
             }
           },
           {
-            "name": "timeZone",
+            "name": "TimeZone",
             "in": "query",
             "description": "The time zone. See https://en.wikipedia.org/wiki/List_of_tz_database_time_zones for a list of valid time zones.",
             "schema": {
@@ -99,7 +99,7 @@
             }
           },
           {
-            "name": "start",
+            "name": "Start",
             "in": "query",
             "description": "The start of the time range in Unix time in seconds.",
             "schema": {
@@ -108,7 +108,7 @@
             }
           },
           {
-            "name": "end",
+            "name": "End",
             "in": "query",
             "description": "The end of the time range in Unix time in seconds.",
             "schema": {
@@ -117,7 +117,7 @@
             }
           },
           {
-            "name": "type",
+            "name": "Type",
             "in": "query",
             "description": "Filter the type of certificates to return.",
             "schema": {
@@ -125,7 +125,7 @@
             }
           },
           {
-            "name": "limit",
+            "name": "Limit",
             "in": "query",
             "description": "The number of items to return.",
             "schema": {
@@ -134,7 +134,7 @@
             }
           },
           {
-            "name": "skip",
+            "name": "Skip",
             "in": "query",
             "description": "The number of items to skip.",
             "schema": {

--- a/src/ProjectOrigin.WalletSystem.IntegrationTests/ApiTests/ApiTests.open_api_specification_not_changed.verified.txt
+++ b/src/ProjectOrigin.WalletSystem.IntegrationTests/ApiTests/ApiTests.open_api_specification_not_changed.verified.txt
@@ -172,7 +172,7 @@
         "summary": "Gets all claims in the wallet",
         "parameters": [
           {
-            "name": "start",
+            "name": "Start",
             "in": "query",
             "description": "The start of the time range in Unix time in seconds.",
             "schema": {
@@ -181,7 +181,7 @@
             }
           },
           {
-            "name": "end",
+            "name": "End",
             "in": "query",
             "description": "The end of the time range in Unix time in seconds.",
             "schema": {
@@ -190,7 +190,7 @@
             }
           },
           {
-            "name": "limit",
+            "name": "Limit",
             "in": "query",
             "description": "The number of items to return.",
             "schema": {
@@ -199,7 +199,7 @@
             }
           },
           {
-            "name": "skip",
+            "name": "Skip",
             "in": "query",
             "description": "The number of items to skip.",
             "schema": {
@@ -275,7 +275,7 @@
         "summary": "Returns a list of aggregates claims for the authenticated user based on the specified time zone and time range.",
         "parameters": [
           {
-            "name": "timeAggregate",
+            "name": "TimeAggregate",
             "in": "query",
             "description": "The size of each bucket in the aggregation",
             "schema": {
@@ -283,7 +283,7 @@
             }
           },
           {
-            "name": "timeZone",
+            "name": "TimeZone",
             "in": "query",
             "description": "The time zone. See https://en.wikipedia.org/wiki/List_of_tz_database_time_zones for a list of valid time zones.",
             "schema": {
@@ -291,7 +291,7 @@
             }
           },
           {
-            "name": "start",
+            "name": "Start",
             "in": "query",
             "description": "The start of the time range in Unix time in seconds.",
             "schema": {
@@ -300,7 +300,7 @@
             }
           },
           {
-            "name": "end",
+            "name": "End",
             "in": "query",
             "description": "The end of the time range in Unix time in seconds.",
             "schema": {
@@ -309,7 +309,7 @@
             }
           },
           {
-            "name": "limit",
+            "name": "Limit",
             "in": "query",
             "description": "The number of items to return.",
             "schema": {
@@ -318,7 +318,7 @@
             }
           },
           {
-            "name": "skip",
+            "name": "Skip",
             "in": "query",
             "description": "The number of items to skip.",
             "schema": {

--- a/src/ProjectOrigin.WalletSystem.IntegrationTests/REST/CertificatesControllerTests.cs
+++ b/src/ProjectOrigin.WalletSystem.IntegrationTests/REST/CertificatesControllerTests.cs
@@ -34,12 +34,7 @@ public class CertificatesControllerTests : IClassFixture<PostgresDatabaseFixture
         var controller = new CertificatesController();
 
         // Act
-        var result = await controller.GetCertificates(
-            _unitOfWork,
-            null,
-            null,
-            null,
-            null);
+        var result = await controller.GetCertificates(_unitOfWork, new GetCertificatesQueryParameters());
 
         // Assert
         result.Result.Should().BeOfType<UnauthorizedResult>();
@@ -88,12 +83,14 @@ public class CertificatesControllerTests : IClassFixture<PostgresDatabaseFixture
         // Act
         var result = await controller.AggregateCertificates(
             _unitOfWork,
-            TimeAggregate.Day,
-            timezone,
-            queryStartDate.ToUnixTimeSeconds(),
-            queryEndDate.ToUnixTimeSeconds(),
-            type,
-            null);
+            new AggregateCertificatesQueryParameters
+            {
+                TimeAggregate = TimeAggregate.Day,
+                TimeZone = timezone,
+                Start = queryStartDate.ToUnixTimeSeconds(),
+                End = queryEndDate.ToUnixTimeSeconds(),
+                Type = type
+            });
 
         // Assert
         result.Value.Should().NotBeNull();
@@ -116,12 +113,11 @@ public class CertificatesControllerTests : IClassFixture<PostgresDatabaseFixture
         // Act
         var result = await controller.AggregateCertificates(
             _unitOfWork,
-            TimeAggregate.Day,
-            "invalid-time-zone",
-            null,
-            null,
-            null,
-            null);
+            new AggregateCertificatesQueryParameters
+            {
+                TimeAggregate = TimeAggregate.Day,
+                TimeZone = "invalid-time-zone",
+            });
 
         // Assert
         result.Result.Should().BeOfType<BadRequestObjectResult>();

--- a/src/ProjectOrigin.WalletSystem.IntegrationTests/REST/ClaimsControllerTests.cs
+++ b/src/ProjectOrigin.WalletSystem.IntegrationTests/REST/ClaimsControllerTests.cs
@@ -40,9 +40,7 @@ public class ClaimsControllerTests : IClassFixture<PostgresDatabaseFixture>
         // Act
         var result = await controller.GetClaims(
             _unitOfWork,
-            null,
-            null,
-            null);
+            new GetClaimsQueryParameters());
 
         // Assert
         result.Result.Should().BeOfType<UnauthorizedResult>();
@@ -93,11 +91,13 @@ public class ClaimsControllerTests : IClassFixture<PostgresDatabaseFixture>
         // Act
         var result = await controller.AggregateClaims(
             _unitOfWork,
-            TimeAggregate.Day,
-            timezone,
-            queryStartDate.ToUnixTimeSeconds(),
-            queryEndDate.ToUnixTimeSeconds(),
-            null);
+            new AggregateClaimsQueryParameters
+            {
+                TimeAggregate = TimeAggregate.Day,
+                TimeZone = timezone,
+                Start = queryStartDate.ToUnixTimeSeconds(),
+                End = queryEndDate.ToUnixTimeSeconds()
+            });
 
         // Assert
         result.Value.Should().NotBeNull();
@@ -120,11 +120,11 @@ public class ClaimsControllerTests : IClassFixture<PostgresDatabaseFixture>
         // Act
         var result = await controller.AggregateClaims(
             _unitOfWork,
-            TimeAggregate.Day,
-            "invalid-time-zone",
-            null,
-            null,
-            null);
+            new AggregateClaimsQueryParameters
+            {
+                TimeAggregate = TimeAggregate.Day,
+                TimeZone = "invalid-time-zone"
+            });
 
         // Assert
         result.Result.Should().BeOfType<BadRequestObjectResult>();

--- a/src/ProjectOrigin.WalletSystem.IntegrationTests/REST/WalletControllerTests.cs
+++ b/src/ProjectOrigin.WalletSystem.IntegrationTests/REST/WalletControllerTests.cs
@@ -139,7 +139,7 @@ public class WalletControllerTests : IClassFixture<PostgresDatabaseFixture>
     }
 
     [Fact]
-    public async Task Verify_OnlySingleAllowedPerSubject()
+    public async Task Verify_MultipleWalletsAllowedPerSubject()
     {
         // Arrange
         var subject = _fixture.Create<string>();
@@ -154,7 +154,8 @@ public class WalletControllerTests : IClassFixture<PostgresDatabaseFixture>
             _options,
             new CreateWalletRequest());
 
-        firstCreateResult.Result.Should().BeOfType<CreatedResult>();
+        var firstResponse = firstCreateResult.Result.Should().BeOfType<CreatedResult>()
+                .Which.Value.Should().BeOfType<CreateWalletResponse>().Which;
 
         // Act
         var secondCreateResult = await controller.CreateWallet(
@@ -164,8 +165,9 @@ public class WalletControllerTests : IClassFixture<PostgresDatabaseFixture>
             new CreateWalletRequest());
 
         // Assert
-        secondCreateResult.Result.Should().BeOfType<BadRequestObjectResult>()
-            .Which.Value.Should().Be("Wallet already exists.");
+        var secondResponse = secondCreateResult.Result.Should().BeOfType<CreatedResult>()
+                .Which.Value.Should().BeOfType<CreateWalletResponse>().Which;
+        firstResponse.WalletId.Should().NotBe(secondResponse.WalletId);
     }
 
     [Fact]

--- a/src/ProjectOrigin.WalletSystem.Server/Database/Postgres/Scripts/v2/v2-0005.sql
+++ b/src/ProjectOrigin.WalletSystem.Server/Database/Postgres/Scripts/v2/v2-0005.sql
@@ -1,0 +1,2 @@
+-- Modify the wallets table to remove the unique constraint on the owner column
+ALTER TABLE wallets DROP CONSTRAINT wallets_owner_key1;

--- a/src/ProjectOrigin.WalletSystem.Server/Services/REST/v1/ClaimsController.cs
+++ b/src/ProjectOrigin.WalletSystem.Server/Services/REST/v1/ClaimsController.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Threading.Tasks;
 using MassTransit;
@@ -20,11 +21,6 @@ public class ClaimsController : ControllerBase
     /// <summary>
     /// Gets all claims in the wallet
     /// </summary>
-    /// <param name="unitOfWork"></param>
-    /// <param name="start">The start of the time range in Unix time in seconds.</param>
-    /// <param name="end">The end of the time range in Unix time in seconds.</param>
-    /// <param name="skip">The number of items to skip.</param>
-    /// <param name="limit">The number of items to return.</param>
     /// <response code="200">Returns all the indiviual claims.</response>
     /// <response code="401">If the user is not authenticated.</response>
     [HttpGet]
@@ -34,20 +30,17 @@ public class ClaimsController : ControllerBase
     [ProducesResponseType(typeof(void), StatusCodes.Status401Unauthorized)]
     public async Task<ActionResult<ResultList<Claim>>> GetClaims(
         [FromServices] IUnitOfWork unitOfWork,
-        [FromQuery] long? start,
-        [FromQuery] long? end,
-        [FromQuery] int? limit,
-        [FromQuery] int skip = 0)
+        [FromQuery] GetClaimsQueryParameters param)
     {
         if (!User.TryGetSubject(out var subject)) return Unauthorized();
 
         var claims = await unitOfWork.ClaimRepository.QueryClaims(new ClaimFilter
         {
             Owner = subject,
-            Start = start != null ? DateTimeOffset.FromUnixTimeSeconds(start.Value) : null,
-            End = end != null ? DateTimeOffset.FromUnixTimeSeconds(end.Value) : null,
-            Skip = skip,
-            Limit = limit ?? int.MaxValue,
+            Start = param.Start != null ? DateTimeOffset.FromUnixTimeSeconds(param.Start.Value) : null,
+            End = param.End != null ? DateTimeOffset.FromUnixTimeSeconds(param.End.Value) : null,
+            Skip = param.Skip,
+            Limit = param.Limit ?? int.MaxValue,
         });
 
         return claims.ToResultList(c => c.MapToV1());
@@ -56,13 +49,6 @@ public class ClaimsController : ControllerBase
     /// <summary>
     /// Returns a list of aggregates claims for the authenticated user based on the specified time zone and time range.
     /// </summary>
-    /// <param name="unitOfWork"></param>
-    /// <param name="timeAggregate">The size of each bucket in the aggregation</param>
-    /// <param name="timeZone">The time zone. See https://en.wikipedia.org/wiki/List_of_tz_database_time_zones for a list of valid time zones.</param>
-    /// <param name="start">The start of the time range in Unix time in seconds.</param>
-    /// <param name="end">The end of the time range in Unix time in seconds.</param>
-    /// <param name="skip">The number of items to skip.</param>
-    /// <param name="limit">The number of items to return.</param>
     /// <response code="200">Returns the aggregated claims.</response>
     /// <response code="400">If the time zone is invalid.</response>
     /// <response code="401">If the user is not authenticated.</response>
@@ -74,24 +60,19 @@ public class ClaimsController : ControllerBase
     [ProducesResponseType(typeof(void), StatusCodes.Status401Unauthorized)]
     public async Task<ActionResult<ResultList<AggregatedClaims>>> AggregateClaims(
         [FromServices] IUnitOfWork unitOfWork,
-        [FromQuery] TimeAggregate timeAggregate,
-        [FromQuery] string timeZone,
-        [FromQuery] long? start,
-        [FromQuery] long? end,
-        [FromQuery] int? limit,
-        [FromQuery] int skip = 0)
+        [FromQuery] AggregateClaimsQueryParameters param)
     {
         if (!User.TryGetSubject(out var subject)) return Unauthorized();
-        if (!timeZone.TryParseTimeZone(out var timeZoneInfo)) return BadRequest("Invalid time zone");
+        if (!param.TimeZone.TryParseTimeZone(out var timeZoneInfo)) return BadRequest("Invalid time zone");
 
         var result = await unitOfWork.ClaimRepository.QueryAggregatedClaims(new ClaimFilter
         {
             Owner = subject,
-            Start = start != null ? DateTimeOffset.FromUnixTimeSeconds(start.Value) : null,
-            End = end != null ? DateTimeOffset.FromUnixTimeSeconds(end.Value) : null,
-            Skip = skip,
-            Limit = limit ?? int.MaxValue
-        }, (Models.TimeAggregate)timeAggregate, timeZone);
+            Start = param.Start != null ? DateTimeOffset.FromUnixTimeSeconds(param.Start.Value) : null,
+            End = param.End != null ? DateTimeOffset.FromUnixTimeSeconds(param.End.Value) : null,
+            Skip = param.Skip,
+            Limit = param.Limit ?? int.MaxValue
+        }, (Models.TimeAggregate)param.TimeAggregate, param.TimeZone);
 
         return result.ToResultList(c => new AggregatedClaims()
         {
@@ -141,6 +122,64 @@ public class ClaimsController : ControllerBase
 }
 
 #region Records
+
+public record GetClaimsQueryParameters
+{
+    /// <summary>
+    /// The start of the time range in Unix time in seconds.
+    /// </summary>
+    public long? Start { get; init; }
+
+    /// <summary>
+    /// The end of the time range in Unix time in seconds.
+    /// </summary>
+    public long? End { get; init; }
+
+    /// <summary>
+    /// The number of items to return.
+    /// </summary>
+    public int? Limit { get; init; }
+
+    /// <summary>
+    /// The number of items to skip.
+    /// </summary>
+    [DefaultValue(0)]
+    public int Skip { get; init; }
+}
+
+public record AggregateClaimsQueryParameters
+{
+    /// <summary>
+    /// The size of each bucket in the aggregation
+    /// </summary>
+    public required TimeAggregate TimeAggregate { get; init; }
+
+    /// <summary>
+    /// The time zone. See https://en.wikipedia.org/wiki/List_of_tz_database_time_zones for a list of valid time zones.
+    /// </summary>
+    public required string TimeZone { get; init; }
+
+    /// <summary>
+    /// The start of the time range in Unix time in seconds.
+    /// </summary>
+    public long? Start { get; init; }
+
+    /// <summary>
+    /// The end of the time range in Unix time in seconds.
+    /// </summary>
+    public long? End { get; init; }
+
+    /// <summary>
+    /// The number of items to return.
+    /// </summary>
+    public int? Limit { get; init; }
+
+    /// <summary>
+    /// The number of items to skip.
+    /// </summary>
+    [DefaultValue(0)]
+    public int Skip { get; init; }
+}
 
 /// <summary>
 /// A claim record representing a claim of a production and consumption certificate.


### PR DESCRIPTION
This adds support for a subject/user in the wallet to create multiple wallets. 

All query apis returns results for the subject and not on an individual wallet level. 

This is a precursor of future implementations which will enable a user to delegate access to a specific wallet to other users. 
