### PR TITLE
Add wallet description tag to OpenApi Spec

### DIFF
--- a/src/ProjectOrigin.WalletSystem.IntegrationTests/ApiTests/ApiBasePathTests.SwaggerJson_VerifyWalletTagContent.verified.txt
+++ b/src/ProjectOrigin.WalletSystem.IntegrationTests/ApiTests/ApiBasePathTests.SwaggerJson_VerifyWalletTagContent.verified.txt
@@ -1,0 +1,6 @@
+﻿{
+  Name: Wallet,
+  Description:
+The Wallet is essential for Energy Origin, since it keeps track of all the user’s Granular Certificates – both the ones generated from the user’s own metering points, but also the ones transferred from other users. In other words, the Wallet will hold all available certificates for the user. Moreover, it will show all transfers, that may have been made, to other users’ wallets as well.
+
+}

--- a/src/ProjectOrigin.WalletSystem.IntegrationTests/ApiTests/ApiTests.open_api_specification_not_changed.verified.txt
+++ b/src/ProjectOrigin.WalletSystem.IntegrationTests/ApiTests/ApiTests.open_api_specification_not_changed.verified.txt
@@ -1383,5 +1383,11 @@
         "additionalProperties": false
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "Wallet",
+      "description": "The Wallet is essential for Energy Origin, since it keeps track of all the user’s Granular Certificates – both the ones generated from the user’s own metering points, but also the ones transferred from other users. In other words, the Wallet will hold all available certificates for the user. Moreover, it will show all transfers, that may have been made, to other users’ wallets as well.\n"
+    }
+  ]
 }

--- a/src/ProjectOrigin.WalletSystem.IntegrationTests/TelemetryTest/TelemetryIntegrationTest.cs
+++ b/src/ProjectOrigin.WalletSystem.IntegrationTests/TelemetryTest/TelemetryIntegrationTest.cs
@@ -93,7 +93,7 @@ public class TelemetryIntegrationTest : IClassFixture<TestServerFixture<Startup>
 
         await client.GetAsync("/health");
 
-        await Task.Delay(1100);
+        await Task.Delay(1200);
 
         var incomingRequests = _wireMockServer.LogEntries
             .ToList();

--- a/src/ProjectOrigin.WalletSystem.Server/ProjectOrigin.WalletSystem.Server.csproj
+++ b/src/ProjectOrigin.WalletSystem.Server/ProjectOrigin.WalletSystem.Server.csproj
@@ -32,6 +32,7 @@
     <PackageReference Include="Serilog.Enrichers.Span" Version="3.1.0" />
     <PackageReference Include="Serilog.Expressions" Version="4.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ProjectOrigin.WalletSystem.Server/Services/REST/AddWalletTagDocumentFilter.cs
+++ b/src/ProjectOrigin.WalletSystem.Server/Services/REST/AddWalletTagDocumentFilter.cs
@@ -1,0 +1,27 @@
+﻿using System.Linq;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace ProjectOrigin.WalletSystem.Server.Services.REST;
+
+public class AddWalletTagDocumentFilter : IDocumentFilter
+{
+    public void Apply(OpenApiDocument swaggerDoc, DocumentFilterContext context)
+    {
+        // Check if the "Contracts" tag already exists to avoid duplicates
+        if (!swaggerDoc.Tags.Any(tag => tag.Name == "Wallet"))
+        {
+            swaggerDoc.Tags.Add(new OpenApiTag
+            {
+                Name = "Wallet",
+                Description = "The Wallet is essential for Energy Origin," +
+                              " since it keeps track of all the user’s Granular Certificates" +
+                              " – both the ones generated from the user’s own metering points," +
+                              " but also the ones transferred from other users." +
+                              " In other words, the Wallet will hold all available certificates for the user." +
+                              " Moreover, it will show all transfers, that may have been made," +
+                              " to other users’ wallets as well.\n"
+            });
+        }
+    }
+}

--- a/src/ProjectOrigin.WalletSystem.Server/Services/REST/AddWalletTagDocumentFilter.cs
+++ b/src/ProjectOrigin.WalletSystem.Server/Services/REST/AddWalletTagDocumentFilter.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.SwaggerGen;
 

--- a/src/ProjectOrigin.WalletSystem.Server/Startup.cs
+++ b/src/ProjectOrigin.WalletSystem.Server/Startup.cs
@@ -170,10 +170,12 @@ public class Startup
 
         services.AddSwaggerGen(options =>
         {
+            options.EnableAnnotations();
             options.SchemaFilter<IHDPublicKeySchemaFilter>();
             var xmlFile = $"{Assembly.GetExecutingAssembly().GetName().Name}.xml";
             var xmlPath = Path.Combine(AppContext.BaseDirectory, xmlFile);
             options.IncludeXmlComments(xmlPath);
+            options.DocumentFilter<AddWalletTagDocumentFilter>();
         });
     }
 


### PR DESCRIPTION
As we are slowly beginning to onboard third party clients into the use of the wallet API, we are starting the enrich the OpenApi Specification, with description tags. ```/Wallet``` is the first to receive a description. The goal is to describe the purpose and use case(s), of the API.