### PR TITLE
Added scope authentication in wallet

### DIFF
--- a/charts/project-origin-wallet/templates/deployment-wallet.yaml
+++ b/charts/project-origin-wallet/templates/deployment-wallet.yaml
@@ -106,6 +106,8 @@ spec:
               value: {{ .Values.config.jwt.audience }}
             - name: jwt__allowAnyJwtToken
               value: {{ .Values.config.jwt.allowAnyJwtToken | quote }}
+            - name: jwt__enableScopeValidation
+              value: {{ .Values.config.jwt.enableScopeValidation | quote }}
             {{- range  $i, $issuer := .Values.config.jwt.issuers }}
             - name: jwt__issuers__{{ $i }}__name
               value: {{ $issuer.name }}

--- a/charts/project-origin-wallet/values.yaml
+++ b/charts/project-origin-wallet/values.yaml
@@ -31,6 +31,9 @@ config:
     # audience defines the audience to use for the jwt tokens, defaults to empty string, which means the audience is not checked
     audience: ""
 
+    # enableScopeValidation determines if scope validation is enabled, defaults to false, if set to true then scope validation is enabled
+    enableScopeValidation: false
+
     # allowAnyJwtToken determines if any jwt token is allowed, defaults to false, if set to true then any jwt token is allowed, NOT RECOMMENDED FOR PRODUCTION!
     allowAnyJwtToken: false
 

--- a/charts/project-origin-wallet/values.yaml
+++ b/charts/project-origin-wallet/values.yaml
@@ -32,7 +32,7 @@ config:
     audience: ""
 
     # enableScopeValidation determines if scope validation is enabled, defaults to false, if set to true then scope validation is enabled
-    enableScopeValidation: false
+    enableScopeValidation: true
 
     # allowAnyJwtToken determines if any jwt token is allowed, defaults to false, if set to true then any jwt token is allowed, NOT RECOMMENDED FOR PRODUCTION!
     allowAnyJwtToken: false

--- a/charts/project-origin-wallet/values.yaml
+++ b/charts/project-origin-wallet/values.yaml
@@ -31,7 +31,7 @@ config:
     # audience defines the audience to use for the jwt tokens, defaults to empty string, which means the audience is not checked
     audience: ""
 
-    # enableScopeValidation determines if scope validation is enabled, defaults to false, if set to true then scope validation is enabled
+    # enableScopeValidation determines if scope validation is enabled, defaults to true, if set to true then scope validation is enabled
     enableScopeValidation: true
 
     # allowAnyJwtToken determines if any jwt token is allowed, defaults to false, if set to true then any jwt token is allowed, NOT RECOMMENDED FOR PRODUCTION!

--- a/src/ProjectOrigin.WalletSystem.IntegrationTests/ApiTests/ApiTests.cs
+++ b/src/ProjectOrigin.WalletSystem.IntegrationTests/ApiTests/ApiTests.cs
@@ -1,11 +1,8 @@
 using AutoFixture;
-using Dapper;
 using FluentAssertions;
 using Npgsql;
-using ProjectOrigin.HierarchicalDeterministicKeys.Interfaces;
 using ProjectOrigin.WalletSystem.IntegrationTests.TestClassFixtures;
 using ProjectOrigin.WalletSystem.Server;
-using ProjectOrigin.WalletSystem.Server.Database.Mapping;
 using ProjectOrigin.WalletSystem.Server.Models;
 using ProjectOrigin.WalletSystem.Server.Repositories;
 using ProjectOrigin.WalletSystem.Server.Services.REST.v1;
@@ -117,7 +114,7 @@ public class ApiTests : WalletSystemTestsBase, IClassFixture<InMemoryFixture>
                 CertificateType = GranularCertificateType.Production,
                 Attributes = new List<CertificateAttribute>
                 {
-                    new() { Key = "AssetId", Value = "571234567890123456", Type = CertificateAttributeType.ClearText },
+                    new() { Key="AssetId", Value="571234567890123456", Type=CertificateAttributeType.ClearText },
                     new() { Key="TechCode", Value="T070000", Type=CertificateAttributeType.ClearText},
                     new() { Key="FuelCode", Value="F00000000", Type=CertificateAttributeType.ClearText},
                 }
@@ -132,7 +129,7 @@ public class ApiTests : WalletSystemTestsBase, IClassFixture<InMemoryFixture>
                 CertificateType = GranularCertificateType.Consumption,
                 Attributes = new List<CertificateAttribute>
                 {
-                    new() { Key = "AssetId", Value = "571234567891234567", Type = CertificateAttributeType.ClearText },
+                    new() { Key="AssetId", Value="571234567891234567", Type=CertificateAttributeType.ClearText },
                 }
             };
             await certificateRepository.InsertCertificate(productionCertificate);

--- a/src/ProjectOrigin.WalletSystem.IntegrationTests/ApiTests/AuthTests.cs
+++ b/src/ProjectOrigin.WalletSystem.IntegrationTests/ApiTests/AuthTests.cs
@@ -58,14 +58,14 @@ public class AuthTests : WalletSystemTestsBase, IClassFixture<InMemoryFixture>
     }
 
     [Theory]
-    [InlineData("wallet:read", "v1/wallets", HttpStatusCode.OK)]
-    [InlineData("wallet:read", $"v1/wallets/{EndpointId}", HttpStatusCode.NotFound)]
-    [InlineData("certificate:read", "v1/certificates", HttpStatusCode.OK)]
-    [InlineData("certificate:read", $"v1/aggregate-certificates?{AggregateParam}", HttpStatusCode.OK)]
-    [InlineData("claim:read", "v1/claims", HttpStatusCode.OK)]
-    [InlineData("claim:read", $"v1/aggregate-claims?{AggregateParam}", HttpStatusCode.OK)]
-    [InlineData("transfer:read", "v1/transfers", HttpStatusCode.OK)]
-    [InlineData("transfer:read", $"v1/aggregate-transfers??{AggregateParam}", HttpStatusCode.OK)]
+    [InlineData("po:wallets:read", "v1/wallets", HttpStatusCode.OK)]
+    [InlineData("po:wallets:read", $"v1/wallets/{EndpointId}", HttpStatusCode.NotFound)]
+    [InlineData("po:certificates:read", "v1/certificates", HttpStatusCode.OK)]
+    [InlineData("po:certificates:read", $"v1/aggregate-certificates?{AggregateParam}", HttpStatusCode.OK)]
+    [InlineData("po:claims:read", "v1/claims", HttpStatusCode.OK)]
+    [InlineData("po:claims:read", $"v1/aggregate-claims?{AggregateParam}", HttpStatusCode.OK)]
+    [InlineData("po:transfers:read", "v1/transfers", HttpStatusCode.OK)]
+    [InlineData("po:transfers:read", $"v1/aggregate-transfers??{AggregateParam}", HttpStatusCode.OK)]
     public async Task Verify_Get_Allowed(string scope, string url, HttpStatusCode expected)
     {
         //Arrange
@@ -102,11 +102,11 @@ public class AuthTests : WalletSystemTestsBase, IClassFixture<InMemoryFixture>
     }
 
     [Theory]
-    [InlineData("wallet:create", "v1/wallets", HttpStatusCode.Created)]
-    [InlineData("wallet-endpoint:create", $"v1/wallets/{EndpointId}/endpoints", HttpStatusCode.NotFound)]
-    [InlineData("external-endpoint:create", "v1/external-endpoints", HttpStatusCode.BadRequest)]
-    [InlineData("claim:create", "v1/claims", HttpStatusCode.BadRequest)]
-    [InlineData("transfer:create", "v1/transfers", HttpStatusCode.BadRequest)]
+    [InlineData("po:wallets:create", "v1/wallets", HttpStatusCode.Created)]
+    [InlineData("po:wallet-endpoints:create", $"v1/wallets/{EndpointId}/endpoints", HttpStatusCode.NotFound)]
+    [InlineData("po:external-endpoints:create", "v1/external-endpoints", HttpStatusCode.BadRequest)]
+    [InlineData("po:claims:create", "v1/claims", HttpStatusCode.BadRequest)]
+    [InlineData("po:transfers:create", "v1/transfers", HttpStatusCode.BadRequest)]
     public async Task Verify_Post_Allowed(string scope, string url, HttpStatusCode expected)
     {
         //Arrange

--- a/src/ProjectOrigin.WalletSystem.IntegrationTests/ApiTests/AuthTests.cs
+++ b/src/ProjectOrigin.WalletSystem.IntegrationTests/ApiTests/AuthTests.cs
@@ -1,0 +1,115 @@
+using AutoFixture;
+using FluentAssertions;
+using ProjectOrigin.WalletSystem.IntegrationTests.TestClassFixtures;
+using ProjectOrigin.WalletSystem.Server;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace ProjectOrigin.WalletSystem.IntegrationTests;
+
+public class AuthTests : WalletSystemTestsBase, IClassFixture<InMemoryFixture>
+{
+    public AuthTests(
+        TestServerFixture<Startup> serverFixture,
+        PostgresDatabaseFixture dbFixture,
+        InMemoryFixture inMemoryFixture,
+        JwtTokenIssuerFixture jwtTokenIssuerFixture,
+        ITestOutputHelper outputHelper)
+        : base(
+              serverFixture,
+              dbFixture,
+              inMemoryFixture,
+              jwtTokenIssuerFixture,
+              outputHelper,
+              null)
+    {
+        serverFixture.ConfigureHostConfiguration(new(){
+            {"Jwt:EnableScopeValidation", "true"}
+        });
+    }
+
+    [Theory]
+    [InlineData("v1/certificates")]
+    [InlineData("v1/aggregate-certificates?timeAggregate=hour&timeZone=Europe/Copenhagen")]
+    [InlineData("v1/claims")]
+    [InlineData("v1/aggregate-claims?timeAggregate=hour&timeZone=Europe/Copenhagen")]
+    [InlineData("v1/transfers")]
+    [InlineData("v1/aggregate-transfers?timeAggregate=hour&timeZone=Europe/Copenhagen")]
+    public async Task Verify_Get_Forbidden(string url)
+    {
+        //Arrange
+        var httpClient = CreateAuthenticatedHttpClient(
+            _fixture.Create<string>(),
+            _fixture.Create<string>());
+
+        //Act
+        var res = await httpClient.GetAsync(url);
+
+        //Assert
+        res.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Theory]
+    [InlineData("certificate:read", "v1/certificates")]
+    [InlineData("certificate:read", "v1/aggregate-certificates?timeAggregate=hour&timeZone=Europe/Copenhagen")]
+    [InlineData("claim:read", "v1/claims")]
+    [InlineData("claim:read", "v1/aggregate-claims?timeAggregate=hour&timeZone=Europe/Copenhagen")]
+    [InlineData("transfer:read", "v1/transfers")]
+    [InlineData("transfer:read", "v1/aggregate-transfers?timeAggregate=hour&timeZone=Europe/Copenhagen")]
+    public async Task Verify_Get_Allowed(string scope, string url)
+    {
+        //Arrange
+        var httpClient = CreateAuthenticatedHttpClient(
+            _fixture.Create<string>(),
+            _fixture.Create<string>(),
+            scopes: [scope]);
+
+        //Act
+        var res = await httpClient.GetAsync(url);
+
+        //Assert
+        res.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Theory]
+    [InlineData("v1/claims")]
+    [InlineData("v1/transfers")]
+    public async Task Verify_Post_Forbidden(string url)
+    {
+        //Arrange
+        var httpClient = CreateAuthenticatedHttpClient(
+            _fixture.Create<string>(),
+            _fixture.Create<string>());
+
+        //Act
+        var res = await httpClient.PostAsync(url, JsonContent.Create(new { }));
+
+        //Assert
+        res.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Theory]
+    [InlineData("claim:create", "v1/claims")]
+    [InlineData("transfer:create", "v1/transfers")]
+    /// <summary>
+    /// Bad request equals that call was allowed but the request was not valid.
+    /// </summary>
+    public async Task Verify_Post_Allowed(string scope, string url)
+    {
+        //Arrange
+        var httpClient = CreateAuthenticatedHttpClient(
+            _fixture.Create<string>(),
+            _fixture.Create<string>(),
+            scopes: [scope]);
+
+        //Act
+        var res = await httpClient.PostAsync(url, JsonContent.Create(new { }));
+
+        //Assert
+        res.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+}

--- a/src/ProjectOrigin.WalletSystem.IntegrationTests/Jwt/JwtTests.cs
+++ b/src/ProjectOrigin.WalletSystem.IntegrationTests/Jwt/JwtTests.cs
@@ -228,7 +228,7 @@ public class JwtTests : IClassFixture<PostgresDatabaseFixture>, IClassFixture<In
 
         // Assert
         await testMethod.Should().ThrowAsync<ValidationException>()
-            .WithMessage("Issuer key could not be imported as type ”rsa”, No supported key formats were found. Check that the input represents the contents of a PEM-encoded key file, not the path to such a file. (Parameter 'input')");
+            .WithMessage("Issuer key could not be imported as type ”RSA”, No supported key formats were found. Check that the input represents the contents of a PEM-encoded key file, not the path to such a file. (Parameter 'input')");
     }
 
     [Fact]

--- a/src/ProjectOrigin.WalletSystem.IntegrationTests/Jwt/JwtTests.cs
+++ b/src/ProjectOrigin.WalletSystem.IntegrationTests/Jwt/JwtTests.cs
@@ -228,7 +228,7 @@ public class JwtTests : IClassFixture<PostgresDatabaseFixture>, IClassFixture<In
 
         // Assert
         await testMethod.Should().ThrowAsync<ValidationException>()
-            .WithMessage("Issuer key could not be imported as type ”ecdsa”, No supported key formats were found. Check that the input represents the contents of a PEM-encoded key file, not the path to such a file. (Parameter 'input')");
+            .WithMessage("Issuer key could not be imported as type ”rsa”, No supported key formats were found. Check that the input represents the contents of a PEM-encoded key file, not the path to such a file. (Parameter 'input')");
     }
 
     [Fact]

--- a/src/ProjectOrigin.WalletSystem.IntegrationTests/JwtTests.cs
+++ b/src/ProjectOrigin.WalletSystem.IntegrationTests/JwtTests.cs
@@ -197,8 +197,8 @@ public class JwtTests : IClassFixture<PostgresDatabaseFixture>, IClassFixture<In
         var testMethod = () => TestGrpc(jwtTokenIssuerFixture, server);
 
         // Assert
-        var rpcException = await testMethod.Should().ThrowAsync<RpcException>();
-        rpcException.WithInnerException<ValidationException>().WithMessage("Issuer key could not be imported as type ”invalidType”, Issuer key type ”invalidType” not implemeted");
+        await testMethod.Should().ThrowAsync<ValidationException>()
+            .WithMessage("Issuer key could not be imported as type ”invalidType”, Issuer key type ”invalidType” not implemeted");
     }
 
     [Fact]
@@ -224,8 +224,8 @@ public class JwtTests : IClassFixture<PostgresDatabaseFixture>, IClassFixture<In
         var testMethod = () => TestGrpc(jwtTokenIssuerFixture, server);
 
         // Assert
-        var rpcException = await testMethod.Should().ThrowAsync<RpcException>();
-        rpcException.WithInnerException<ValidationException>().WithMessage("Issuer key could not be imported as type ”ecdsa”, No supported key formats were found. Check that the input represents the contents of a PEM-encoded key file, not the path to such a file. (Parameter 'input')");
+        await testMethod.Should().ThrowAsync<ValidationException>()
+            .WithMessage("Issuer key could not be imported as type ”ecdsa”, No supported key formats were found. Check that the input represents the contents of a PEM-encoded key file, not the path to such a file. (Parameter 'input')");
     }
 
     private static async Task<CreateWalletDepositEndpointResponse> TestGrpc(JwtTokenIssuerFixture jwtTokenIssuerFixture, TestServerFixture<Startup> server)

--- a/src/ProjectOrigin.WalletSystem.IntegrationTests/TestClassFixtures/JwtTokenIssuerFixture.cs
+++ b/src/ProjectOrigin.WalletSystem.IntegrationTests/TestClassFixtures/JwtTokenIssuerFixture.cs
@@ -27,13 +27,14 @@ public class JwtTokenIssuerFixture : IDisposable
         File.WriteAllText(PemFilepath, pem);
     }
 
-    public string GenerateToken(string subject, string name)
+    public string GenerateToken(string subject, string name, string[]? scopes = null)
     {
         var claims = new[]
         {
             new Claim("sub", subject),
             new Claim("name", name),
             new Claim("iat", DateTimeOffset.UtcNow.ToUnixTimeSeconds().ToString(), ClaimValueTypes.Integer64),
+            new Claim("scope", string.Join(" ", scopes ?? Array.Empty<string>())),
         };
 
         var key = new ECDsaSecurityKey(_ecdsa);

--- a/src/ProjectOrigin.WalletSystem.IntegrationTests/TestClassFixtures/TestServerFixture.cs
+++ b/src/ProjectOrigin.WalletSystem.IntegrationTests/TestClassFixtures/TestServerFixture.cs
@@ -63,7 +63,13 @@ namespace ProjectOrigin.WalletSystem.IntegrationTests.TestClassFixtures
 
         public void ConfigureHostConfiguration(Dictionary<string, string?> configuration)
         {
-            _configurationDictionary = configuration;
+            if (_configurationDictionary != null)
+                foreach (var keyValuePair in configuration)
+                {
+                    _configurationDictionary[keyValuePair.Key] = keyValuePair.Value;
+                }
+            else
+                _configurationDictionary = configuration;
         }
 
         private void EnsureServer()

--- a/src/ProjectOrigin.WalletSystem.IntegrationTests/WalletSystemTestsBase.cs
+++ b/src/ProjectOrigin.WalletSystem.IntegrationTests/WalletSystemTestsBase.cs
@@ -87,10 +87,10 @@ public abstract class WalletSystemTestsBase : IClassFixture<TestServerFixture<St
         Dispose(false);
     }
 
-    protected HttpClient CreateAuthenticatedHttpClient(string subject, string name)
+    protected HttpClient CreateAuthenticatedHttpClient(string subject, string name, string[]? scopes = null)
     {
         var client = _serverFixture.CreateHttpClient();
-        var token = _jwtTokenIssuerFixture.GenerateToken(subject, name);
+        var token = _jwtTokenIssuerFixture.GenerateToken(subject, name, scopes);
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
         return client;
     }

--- a/src/ProjectOrigin.WalletSystem.Server/Extensions/JwtBearerOptionsExtensions.cs
+++ b/src/ProjectOrigin.WalletSystem.Server/Extensions/JwtBearerOptionsExtensions.cs
@@ -11,7 +11,6 @@ public static class JwtBearerOptionsExtensions
 {
     public static void ConfigureJwtVerification(this JwtBearerOptions bearerOptions, JwtOptions jwtOptions)
     {
-
         if (jwtOptions.AllowAnyJwtToken)
         {
             Log.Warning("No JWT issuers configured. Server will accept any jwt-tokens! This is not recommended for production environments.");

--- a/src/ProjectOrigin.WalletSystem.Server/Options/JwtOptions.cs
+++ b/src/ProjectOrigin.WalletSystem.Server/Options/JwtOptions.cs
@@ -9,6 +9,7 @@ public class JwtOptions : IValidatableObject
     public bool AllowAnyJwtToken { get; init; } = false;
     public string Audience { get; init; } = string.Empty;
     public IEnumerable<JwtIssuer> Issuers { get; init; } = new List<JwtIssuer>();
+    public bool EnableScopeValidation { get; init; } = false;
 
     public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
     {

--- a/src/ProjectOrigin.WalletSystem.Server/ProjectOrigin.WalletSystem.Server.csproj
+++ b/src/ProjectOrigin.WalletSystem.Server/ProjectOrigin.WalletSystem.Server.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Npgsql" Version="8.0.2" />
     <PackageReference Include="Npgsql.OpenTelemetry" Version="8.0.2" />
     <PackageReference Include="NSec.Cryptography" Version="22.4.0" />
+    <PackageReference Include="Microsoft.Identity.Web" Version="2.17.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
     <PackageReference Include="OpenTelemetry" Version="1.7.0" />

--- a/src/ProjectOrigin.WalletSystem.Server/Services/REST/v1/CertificatesController.cs
+++ b/src/ProjectOrigin.WalletSystem.Server/Services/REST/v1/CertificatesController.cs
@@ -28,7 +28,7 @@ public class CertificatesController : ControllerBase
     /// <response code="401">If the user is not authenticated.</response>
     [HttpGet]
     [Route("v1/certificates")]
-    [RequiredScope("certificate:read")]
+    [RequiredScope("po:certificates:read")]
     [Produces("application/json")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(void), StatusCodes.Status401Unauthorized)]
@@ -71,7 +71,7 @@ public class CertificatesController : ControllerBase
     /// <response code="401">If the user is not authenticated.</response>
     [HttpGet]
     [Route("v1/aggregate-certificates")]
-    [RequiredScope("certificate:read")]
+    [RequiredScope("po:certificates:read")]
     [Produces("application/json")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(void), StatusCodes.Status400BadRequest)]

--- a/src/ProjectOrigin.WalletSystem.Server/Services/REST/v1/CertificatesController.cs
+++ b/src/ProjectOrigin.WalletSystem.Server/Services/REST/v1/CertificatesController.cs
@@ -1,10 +1,10 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Identity.Web.Resource;
 using ProjectOrigin.WalletSystem.Server.Database;
 using ProjectOrigin.WalletSystem.Server.Extensions;
 using ProjectOrigin.WalletSystem.Server.Models;
@@ -28,6 +28,7 @@ public class CertificatesController : ControllerBase
     /// <response code="401">If the user is not authenticated.</response>
     [HttpGet]
     [Route("v1/certificates")]
+    [RequiredScope("certificate:read")]
     [Produces("application/json")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(void), StatusCodes.Status401Unauthorized)]
@@ -70,6 +71,7 @@ public class CertificatesController : ControllerBase
     /// <response code="401">If the user is not authenticated.</response>
     [HttpGet]
     [Route("v1/aggregate-certificates")]
+    [RequiredScope("certificate:read")]
     [Produces("application/json")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(void), StatusCodes.Status400BadRequest)]

--- a/src/ProjectOrigin.WalletSystem.Server/Services/REST/v1/ClaimsController.cs
+++ b/src/ProjectOrigin.WalletSystem.Server/Services/REST/v1/ClaimsController.cs
@@ -1,11 +1,11 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using MassTransit;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Identity.Web.Resource;
 using ProjectOrigin.WalletSystem.Server.CommandHandlers;
 using ProjectOrigin.WalletSystem.Server.Database;
 using ProjectOrigin.WalletSystem.Server.Extensions;
@@ -29,6 +29,7 @@ public class ClaimsController : ControllerBase
     /// <response code="401">If the user is not authenticated.</response>
     [HttpGet]
     [Route("v1/claims")]
+    [RequiredScope("claim:read")]
     [Produces("application/json")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(void), StatusCodes.Status401Unauthorized)]
@@ -68,6 +69,7 @@ public class ClaimsController : ControllerBase
     /// <response code="401">If the user is not authenticated.</response>
     [HttpGet]
     [Route("v1/aggregate-claims")]
+    [RequiredScope("claim:read")]
     [Produces("application/json")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(void), StatusCodes.Status400BadRequest)]
@@ -110,6 +112,7 @@ public class ClaimsController : ControllerBase
     /// <response code="401">If the user is not authenticated.</response>
     [HttpPost]
     [Route("v1/claims")]
+    [RequiredScope("claim:create")]
     [Produces("application/json")]
     [ProducesResponseType(typeof(ClaimResponse), StatusCodes.Status202Accepted)]
     [ProducesResponseType(typeof(void), StatusCodes.Status401Unauthorized)]

--- a/src/ProjectOrigin.WalletSystem.Server/Services/REST/v1/ClaimsController.cs
+++ b/src/ProjectOrigin.WalletSystem.Server/Services/REST/v1/ClaimsController.cs
@@ -29,7 +29,7 @@ public class ClaimsController : ControllerBase
     /// <response code="401">If the user is not authenticated.</response>
     [HttpGet]
     [Route("v1/claims")]
-    [RequiredScope("claim:read")]
+    [RequiredScope("po:claims:read")]
     [Produces("application/json")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(void), StatusCodes.Status401Unauthorized)]
@@ -69,7 +69,7 @@ public class ClaimsController : ControllerBase
     /// <response code="401">If the user is not authenticated.</response>
     [HttpGet]
     [Route("v1/aggregate-claims")]
-    [RequiredScope("claim:read")]
+    [RequiredScope("po:claims:read")]
     [Produces("application/json")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(void), StatusCodes.Status400BadRequest)]
@@ -112,7 +112,7 @@ public class ClaimsController : ControllerBase
     /// <response code="401">If the user is not authenticated.</response>
     [HttpPost]
     [Route("v1/claims")]
-    [RequiredScope("claim:create")]
+    [RequiredScope("po:claims:create")]
     [Produces("application/json")]
     [ProducesResponseType(typeof(ClaimResponse), StatusCodes.Status202Accepted)]
     [ProducesResponseType(typeof(void), StatusCodes.Status401Unauthorized)]

--- a/src/ProjectOrigin.WalletSystem.Server/Services/REST/v1/TransfersController.cs
+++ b/src/ProjectOrigin.WalletSystem.Server/Services/REST/v1/TransfersController.cs
@@ -28,7 +28,7 @@ public class TransfersController : ControllerBase
     /// <response code="401">If the user is not authenticated.</response>
     [HttpGet]
     [Route("v1/transfers")]
-    [RequiredScope("transfer:read")]
+    [RequiredScope("po:transfers:read")]
     [Produces("application/json")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(void), StatusCodes.Status401Unauthorized)]
@@ -80,7 +80,7 @@ public class TransfersController : ControllerBase
     /// <response code="401">If the user is not authenticated.</response>
     [HttpGet]
     [Route("v1/aggregate-transfers")]
-    [RequiredScope("transfer:read")]
+    [RequiredScope("po:transfers:read")]
     [Produces("application/json")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(void), StatusCodes.Status400BadRequest)]
@@ -123,7 +123,7 @@ public class TransfersController : ControllerBase
     /// <response code="401">If the user is not authenticated.</response>
     [HttpPost]
     [Route("v1/transfers")]
-    [RequiredScope("transfer:create")]
+    [RequiredScope("po:transfers:create")]
     [Produces("application/json")]
     [ProducesResponseType(typeof(TransferResponse), StatusCodes.Status202Accepted)]
     [ProducesResponseType(typeof(void), StatusCodes.Status401Unauthorized)]

--- a/src/ProjectOrigin.WalletSystem.Server/Services/REST/v1/TransfersController.cs
+++ b/src/ProjectOrigin.WalletSystem.Server/Services/REST/v1/TransfersController.cs
@@ -4,6 +4,7 @@ using MassTransit;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Identity.Web.Resource;
 using ProjectOrigin.WalletSystem.Server.CommandHandlers;
 using ProjectOrigin.WalletSystem.Server.Database;
 using ProjectOrigin.WalletSystem.Server.Extensions;
@@ -27,6 +28,7 @@ public class TransfersController : ControllerBase
     /// <response code="401">If the user is not authenticated.</response>
     [HttpGet]
     [Route("v1/transfers")]
+    [RequiredScope("transfer:read")]
     [Produces("application/json")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(void), StatusCodes.Status401Unauthorized)]
@@ -78,6 +80,7 @@ public class TransfersController : ControllerBase
     /// <response code="401">If the user is not authenticated.</response>
     [HttpGet]
     [Route("v1/aggregate-transfers")]
+    [RequiredScope("transfer:read")]
     [Produces("application/json")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(void), StatusCodes.Status400BadRequest)]
@@ -120,6 +123,7 @@ public class TransfersController : ControllerBase
     /// <response code="401">If the user is not authenticated.</response>
     [HttpPost]
     [Route("v1/transfers")]
+    [RequiredScope("transfer:create")]
     [Produces("application/json")]
     [ProducesResponseType(typeof(TransferResponse), StatusCodes.Status202Accepted)]
     [ProducesResponseType(typeof(void), StatusCodes.Status401Unauthorized)]

--- a/src/ProjectOrigin.WalletSystem.Server/Services/REST/v1/WalletController.cs
+++ b/src/ProjectOrigin.WalletSystem.Server/Services/REST/v1/WalletController.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
+using Microsoft.Identity.Web.Resource;
 using ProjectOrigin.HierarchicalDeterministicKeys.Interfaces;
 using ProjectOrigin.WalletSystem.Server.Database;
 using ProjectOrigin.WalletSystem.Server.Extensions;
@@ -34,6 +35,7 @@ public class WalletController : ControllerBase
     /// <response code="401">If the user is not authenticated.</response>
     [HttpPost]
     [Route("v1/wallets")]
+    [RequiredScope("wallet:read")]
     [Produces("application/json")]
     [ProducesResponseType(StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
@@ -89,6 +91,7 @@ public class WalletController : ControllerBase
     /// <response code="401">If the user is not authenticated.</response>
     [HttpGet]
     [Route("v1/wallets")]
+    [RequiredScope("wallet:read")]
     [Produces("application/json")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(void), StatusCodes.Status401Unauthorized)]
@@ -131,6 +134,7 @@ public class WalletController : ControllerBase
     /// <response code="404">If the wallet specified is not found for the user.</response>
     [HttpGet]
     [Route("v1/wallets/{walletId}")]
+    [RequiredScope("wallet:read")]
     [Produces("application/json")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(void), StatusCodes.Status401Unauthorized)]
@@ -164,6 +168,7 @@ public class WalletController : ControllerBase
     /// <response code="404">If the wallet specified is not found for the user.</response>
     [HttpPost]
     [Route("v1/wallets/{walletId}/endpoints")]
+    [RequiredScope("wallet-endpoint:create")]
     [Produces("application/json")]
     [ProducesResponseType(StatusCodes.Status201Created)]
     [ProducesResponseType(typeof(void), StatusCodes.Status401Unauthorized)]
@@ -205,6 +210,7 @@ public class WalletController : ControllerBase
     /// <response code="401">If the user is not authenticated.</response>
     [HttpPost]
     [Route("v1/external-endpoints")]
+    [RequiredScope("external-endpoint:create")]
     [Produces("application/json")]
     [ProducesResponseType(StatusCodes.Status201Created)]
     [ProducesResponseType(typeof(void), StatusCodes.Status401Unauthorized)]

--- a/src/ProjectOrigin.WalletSystem.Server/Services/REST/v1/WalletController.cs
+++ b/src/ProjectOrigin.WalletSystem.Server/Services/REST/v1/WalletController.cs
@@ -35,7 +35,7 @@ public class WalletController : ControllerBase
     /// <response code="401">If the user is not authenticated.</response>
     [HttpPost]
     [Route("v1/wallets")]
-    [RequiredScope("wallet:create")]
+    [RequiredScope("po:wallets:create")]
     [Produces("application/json")]
     [ProducesResponseType(StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
@@ -91,7 +91,7 @@ public class WalletController : ControllerBase
     /// <response code="401">If the user is not authenticated.</response>
     [HttpGet]
     [Route("v1/wallets")]
-    [RequiredScope("wallet:read")]
+    [RequiredScope("po:wallets:read")]
     [Produces("application/json")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(void), StatusCodes.Status401Unauthorized)]
@@ -134,7 +134,7 @@ public class WalletController : ControllerBase
     /// <response code="404">If the wallet specified is not found for the user.</response>
     [HttpGet]
     [Route("v1/wallets/{walletId}")]
-    [RequiredScope("wallet:read")]
+    [RequiredScope("po:wallets:read")]
     [Produces("application/json")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(void), StatusCodes.Status401Unauthorized)]
@@ -168,7 +168,7 @@ public class WalletController : ControllerBase
     /// <response code="404">If the wallet specified is not found for the user.</response>
     [HttpPost]
     [Route("v1/wallets/{walletId}/endpoints")]
-    [RequiredScope("wallet-endpoint:create")]
+    [RequiredScope("po:wallet-endpoints:create")]
     [Produces("application/json")]
     [ProducesResponseType(StatusCodes.Status201Created)]
     [ProducesResponseType(typeof(void), StatusCodes.Status401Unauthorized)]
@@ -210,7 +210,7 @@ public class WalletController : ControllerBase
     /// <response code="401">If the user is not authenticated.</response>
     [HttpPost]
     [Route("v1/external-endpoints")]
-    [RequiredScope("external-endpoint:create")]
+    [RequiredScope("po:external-endpoints:create")]
     [Produces("application/json")]
     [ProducesResponseType(StatusCodes.Status201Created)]
     [ProducesResponseType(typeof(void), StatusCodes.Status401Unauthorized)]

--- a/src/ProjectOrigin.WalletSystem.Server/Services/REST/v1/WalletController.cs
+++ b/src/ProjectOrigin.WalletSystem.Server/Services/REST/v1/WalletController.cs
@@ -35,7 +35,7 @@ public class WalletController : ControllerBase
     /// <response code="401">If the user is not authenticated.</response>
     [HttpPost]
     [Route("v1/wallets")]
-    [RequiredScope("wallet:read")]
+    [RequiredScope("wallet:create")]
     [Produces("application/json")]
     [ProducesResponseType(StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]

--- a/src/ProjectOrigin.WalletSystem.Server/Startup.cs
+++ b/src/ProjectOrigin.WalletSystem.Server/Startup.cs
@@ -31,6 +31,8 @@ using Npgsql;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
+using Microsoft.Identity.Web;
+using Microsoft.IdentityModel.JsonWebTokens;
 
 namespace ProjectOrigin.WalletSystem.Server;
 
@@ -89,14 +91,19 @@ public class Startup
 
         services.ConfigurePersistance(_configuration);
 
+        JsonWebTokenHandler.DefaultInboundClaimTypeMap["scope"] = "http://schemas.microsoft.com/identity/claims/scope";
+        var jwtOptions = _configuration.GetSection("jwt").GetValid<JwtOptions>();
         services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
             .AddJwtBearer(o =>
             {
-                var jwtOptions = _configuration.GetSection("jwt").GetValid<JwtOptions>();
                 o.ConfigureJwtVerification(jwtOptions);
             });
 
         services.AddAuthorization();
+        if (jwtOptions.EnableScopeValidation)
+        {
+            services.AddRequiredScopeAuthorization();
+        }
 
         void ConfigureResource(ResourceBuilder r)
         {


### PR DESCRIPTION
# BREAKING CHANGE

This adds support to verify that the required scopes are  set on the JWT, this is `ENABLED BY DEFAULT` if one wants to disable it, one must do the following in the yaml file

```yaml
config:
  jwt:
    # enableScopeValidation determines if scope validation is enabled, defaults to true, if set to true then scope validation is enabled
    enableScopeValidation: false
```

## List of scopes:

### Wallet

- **GET api/v1/wallets**: `po:wallets:read`
- **GET api/v1/wallets/{walletId}**: `po:wallets:read`
- **POST api/v1/wallets**: `po:wallets:create`
- **POST api/v1/wallets/{walletId}/endpoints**: `po:wallet_endpoints:create`
- **POST api/v1/external-endpoints**: `po:external-endpoints:create`

### Certificates

- **GET /api/v1/certificates**: `po:certificates:read`
- **GET /api/v1/aggregate-certificates**: `po:certificates:read`

### Claims

- **GET /api/v1/claims**: `po:claims:read`
- **GET /api/v1/aggregate-claims**: `po:claims:read`
- **POST /api/v1/claims**: `po:claims:create`

### Transfers

- **GET /api/v1/transfers**: `po:transfers:read`
- **GET /api/v1/aggregate-transfers**: `po:transfers:read`
- **POST /api/v1/transfers**: `po:transfers:create`