### PR TITLE
add-external-postgres-support

### DIFF
--- a/charts/project-origin-wallet/Chart.yaml
+++ b/charts/project-origin-wallet/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: project-origin-wallet
 description: A helm chart for deploying the Project Origin Wallet
 type: application
-version: 0.1.0
-appVersion: "0.1.0"
+version: 0.1.1
+appVersion: "0.1.1"
 
 annotations:
   artifacthub.io/containsSecurityUpdates: "false"

--- a/charts/project-origin-wallet/Chart.yaml
+++ b/charts/project-origin-wallet/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: project-origin-wallet
 description: A helm chart for deploying the Project Origin Wallet
 type: application
-version: 0.1.1
-appVersion: "0.1.1"
+version: 0.1.0
+appVersion: "0.1.0"
 
 annotations:
   artifacthub.io/containsSecurityUpdates: "false"

--- a/charts/project-origin-wallet/templates/cnpg-cluster.yaml
+++ b/charts/project-origin-wallet/templates/cnpg-cluster.yaml
@@ -1,18 +1,18 @@
 ---
-{{- if and (eq .Values.persistance.type "CloudNativePG") }}
+{{- if and (eq .Values.persistence.type "CloudNativePG") }}
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
-  name: {{ .Values.persistance.cloudNativePG.name }}
+  name: {{ .Values.persistence.cloudNativePG.name }}
   namespace: {{ .Release.Namespace }}
 spec:
-  instances: {{ .Values.persistance.cloudNativePG.replicas }}
+  instances: {{ .Values.persistence.cloudNativePG.replicas }}
   storage:
-    size: {{ .Values.persistance.cloudNativePG.size }}
+    size: {{ .Values.persistence.cloudNativePG.size }}
   bootstrap:
     initdb:
-      database: {{ .Values.persistance.cloudNativePG.database }}
-      owner: {{ .Values.persistance.cloudNativePG.owner }}
+      database: {{ .Values.persistence.cloudNativePG.database }}
+      owner: {{ .Values.persistence.cloudNativePG.owner }}
   monitoring:
     enablePodMonitor: true
 {{- end }}

--- a/charts/project-origin-wallet/templates/cnpg-cluster.yaml
+++ b/charts/project-origin-wallet/templates/cnpg-cluster.yaml
@@ -1,5 +1,5 @@
 ---
-{{ if eq .Values.persistance.type "CloudNativePG" }}
+{{- if and (eq .Values.persistance.type "CloudNativePG") (.Values.persistance.enabled) }}
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
@@ -15,4 +15,4 @@ spec:
       owner: {{ .Values.persistance.cloudNativePG.owner }}
   monitoring:
     enablePodMonitor: true
-{{ end }}
+{{- end }}

--- a/charts/project-origin-wallet/templates/cnpg-cluster.yaml
+++ b/charts/project-origin-wallet/templates/cnpg-cluster.yaml
@@ -1,5 +1,5 @@
 ---
-{{- if and (eq .Values.persistance.type "CloudNativePG") (.Values.persistance.enabled) }}
+{{- if and (eq .Values.persistance.type "CloudNativePG") }}
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:

--- a/charts/project-origin-wallet/templates/cnpg-cluster.yaml
+++ b/charts/project-origin-wallet/templates/cnpg-cluster.yaml
@@ -1,5 +1,5 @@
 ---
-{{ if .Values.persistance.cloudNativePG.enabled }}
+{{ if eq .Values.persistance.type "CloudNativePG" }}
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:

--- a/charts/project-origin-wallet/templates/deployment-wallet.yaml
+++ b/charts/project-origin-wallet/templates/deployment-wallet.yaml
@@ -36,10 +36,10 @@ spec:
               value: {{ required "A valid externalUrl is required!"  .Values.config.externalUrl }}
             - name: RestApiOptions__PathBase
               value: {{ .Values.config.pathBase }}
-            {{- if eq .Values.messageBroker.type "inMemory" }}
+          {{- if eq .Values.messageBroker.type "inMemory" }}
             - name: MessageBroker__Type
               value: InMemory
-            {{- else if eq .Values.messageBroker.type "rabbitmq" }}
+          {{- else if eq .Values.messageBroker.type "rabbitmq" }}
             - name: MessageBroker__Type
               value: RabbitMq
             - name: MessageBroker__RabbitMQ__Host
@@ -50,7 +50,7 @@ spec:
               value: {{ required "A valid messageBroker rabbitmq username is required!" .Values.messageBroker.rabbitmq.username }}
             - name: MessageBroker__RabbitMQ__Password
               value: {{ required "A valid messageBroker rabbitmq password is required!" .Values.messageBroker.rabbitmq.password }}
-            {{- else if eq .Values.messageBroker.type "rabbitmqOperator" }}
+          {{- else if eq .Values.messageBroker.type "rabbitmqOperator" }}
             - name: MessageBroker__Type
               value: RabbitMq
             - name: MessageBroker__RabbitMQ__Host
@@ -73,14 +73,16 @@ spec:
                 secretKeyRef:
                   name: {{ .Release.Name }}-rabbitmq-default-user
                   key: password
-            {{- else}}
+          {{- else}}
             {{- fail "messageBroker type must be one of (inMemory | rabbitmq | rabbitmqOperator)" }}
-            {{- end }}
-            {{- range .Values.registries }}
+          {{- end }}
+
+          {{- range .Values.registries }}
             - name: RegistryUrls__{{ .name }}
               value: {{ .address }}
-            {{- end }}
-            {{- if eq .Values.persistance.type "CloudNativePG" }}
+          {{- end }}
+
+          {{- if eq .Values.persistance.type "CloudNativePG" }}
             - name: DB_HOST
               value: {{ .Values.persistance.cloudNativePG.name }}-rw
             - name: DB_PORT
@@ -99,7 +101,7 @@ spec:
                   key: password
             - name: ConnectionStrings__Database
               value: "Host=$(DB_HOST);Port=$(DB_PORT);Database=$(DB_DATABASE);Username=$(DB_USERNAME);Password=$(DB_PASSWORD);"
-            {{- else if eq .Values.persistance.type "BYOD" }}
+          {{- else if eq .Values.persistance.type "BYOD" }}
             - name: ConnectionStrings__Database
               valueFrom:
                 secretKeyRef:
@@ -116,14 +118,14 @@ spec:
               value: {{ .Values.config.jwt.allowAnyJwtToken | quote }}
             - name: jwt__enableScopeValidation
               value: {{ .Values.config.jwt.enableScopeValidation | quote }}
-            {{- range  $i, $issuer := .Values.config.jwt.issuers }}
+          {{- range  $i, $issuer := .Values.config.jwt.issuers }}
             - name: jwt__issuers__{{ $i }}__name
               value: {{ $issuer.name }}
             - name: jwt__issuers__{{ $i }}__type
               value: {{ $issuer.type }}
             - name: jwt__issuers__{{ $i }}__pemFileName
               value: {{ $issuer.pemFileName }}
-            {{- end }}
+          {{- end }}
 
             # OpenTelemetry Collector Configuration
             - name: Otlp__Enabled

--- a/charts/project-origin-wallet/templates/deployment-wallet.yaml
+++ b/charts/project-origin-wallet/templates/deployment-wallet.yaml
@@ -82,33 +82,33 @@ spec:
               value: {{ .address }}
           {{- end }}
 
-          {{- if eq .Values.persistance.type "CloudNativePG" }}
+          {{- if eq .Values.persistence.type "CloudNativePG" }}
             - name: DB_HOST
-              value: {{ .Values.persistance.cloudNativePG.name }}-rw
+              value: {{ .Values.persistence.cloudNativePG.name }}-rw
             - name: DB_PORT
               value: "5432"
             - name: DB_DATABASE
-              value: {{ .Values.persistance.cloudNativePG.database }}
+              value: {{ .Values.persistence.cloudNativePG.database }}
             - name: DB_USERNAME
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.persistance.cloudNativePG.name }}-app
+                  name: {{ .Values.persistence.cloudNativePG.name }}-app
                   key: username
             - name: DB_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.persistance.cloudNativePG.name }}-app
+                  name: {{ .Values.persistence.cloudNativePG.name }}-app
                   key: password
             - name: ConnectionStrings__Database
               value: "Host=$(DB_HOST);Port=$(DB_PORT);Database=$(DB_DATABASE);Username=$(DB_USERNAME);Password=$(DB_PASSWORD);"
-          {{- else if eq .Values.persistance.type "BYOD" }}
+          {{- else if eq .Values.persistence.type "BYOD" }}
             - name: ConnectionStrings__Database
               valueFrom:
                 secretKeyRef:
-                  name: {{ required "BYOD is selected as the database type, but no secretName is provided in persistance.byod" .Values.persistance.byod.secretName }}
-                  key: connectionString
+                  name: {{ required "BYOD is selected as the database type, but no secretName is provided in persistence.byod" .Values.persistence.byod.secretName }}
+                  key: {{ required "BYOD is selected as the database type, but no secretKey is provided in persistence.byod" .Values.persistence.byod.secretKey }}
           {{- else }}
-            {{- fail "Unsupported database type specified. Please specify 'persistance.type' as either 'CloudNativePG' or 'BYOD'." }}
+            {{- fail "Unsupported database type specified. Please specify 'persistence.type' as either 'CloudNativePG' or 'BYOD'." }}
           {{- end }}
             - name: jwt__audience
               value: {{ .Values.config.jwt.audience }}

--- a/charts/project-origin-wallet/templates/deployment-wallet.yaml
+++ b/charts/project-origin-wallet/templates/deployment-wallet.yaml
@@ -109,9 +109,6 @@ spec:
           {{- else }}
             {{- fail "Unsupported database type specified. Please specify 'persistance.type' as either 'CloudNativePG' or 'BYOD'." }}
           {{- end }}
-        {{- else }}
-          {{- /* Configuration or resources related to the database should not be created or applied if persistance.enabled is false. */ }}
-        {{- end }}
             - name: jwt__audience
               value: {{ .Values.config.jwt.audience }}
             - name: jwt__authority

--- a/charts/project-origin-wallet/templates/deployment-wallet.yaml
+++ b/charts/project-origin-wallet/templates/deployment-wallet.yaml
@@ -80,7 +80,8 @@ spec:
             - name: RegistryUrls__{{ .name }}
               value: {{ .address }}
             {{- end }}
-          {{ if .Values.persistance.cloudNativePG.enabled }}
+          {{- if .Values.persistance.enabled }}
+            {{- if eq .Values.persistance.type "CloudNativePG" }}
             - name: DB_HOST
               value: {{ .Values.persistance.cloudNativePG.name }}-rw
             - name: DB_PORT
@@ -98,10 +99,19 @@ spec:
                   name: {{ .Values.persistance.cloudNativePG.name }}-app
                   key: password
             - name: ConnectionStrings__Database
-              value: Host=$(DB_HOST); Port=$(DB_PORT); Database=$(DB_DATABASE); Username=$(DB_USERNAME); Password=$(DB_PASSWORD);
+              value: "Host=$(DB_HOST);Port=$(DB_PORT);Database=$(DB_DATABASE);Username=$(DB_USERNAME);Password=$(DB_PASSWORD);"
+            {{- else if eq .Values.persistance.type "BYOD" }}
+            - name: ConnectionStrings__Database
+              valueFrom:
+                secretKeyRef:
+                  name: {{ required "BYOD is selected as the database type, but no secretName is provided in persistance.byod" .Values.persistance.byod.secretName }}
+                  key: connectionString
           {{- else }}
-            {{- fail "currently only CloudNativePG is supported, and must be enabled." }}
-          {{ end }}
+            {{- fail "Unsupported database type specified. Please specify 'persistance.type' as either 'CloudNativePG' or 'BYOD'." }}
+          {{- end }}
+        {{- else }}
+          {{- /* Configuration or resources related to the database should not be created or applied if persistance.enabled is false. */ }}
+        {{- end }}
             - name: jwt__audience
               value: {{ .Values.config.jwt.audience }}
             - name: jwt__authority

--- a/charts/project-origin-wallet/templates/deployment-wallet.yaml
+++ b/charts/project-origin-wallet/templates/deployment-wallet.yaml
@@ -80,7 +80,6 @@ spec:
             - name: RegistryUrls__{{ .name }}
               value: {{ .address }}
             {{- end }}
-          {{- if .Values.persistance.enabled }}
             {{- if eq .Values.persistance.type "CloudNativePG" }}
             - name: DB_HOST
               value: {{ .Values.persistance.cloudNativePG.name }}-rw
@@ -109,7 +108,6 @@ spec:
           {{- else }}
             {{- fail "Unsupported database type specified. Please specify 'persistance.type' as either 'CloudNativePG' or 'BYOD'." }}
           {{- end }}
-        {{- end }}
             - name: jwt__audience
               value: {{ .Values.config.jwt.audience }}
             - name: jwt__authority

--- a/charts/project-origin-wallet/templates/deployment-wallet.yaml
+++ b/charts/project-origin-wallet/templates/deployment-wallet.yaml
@@ -109,6 +109,7 @@ spec:
           {{- else }}
             {{- fail "Unsupported database type specified. Please specify 'persistance.type' as either 'CloudNativePG' or 'BYOD'." }}
           {{- end }}
+        {{- end }}
             - name: jwt__audience
               value: {{ .Values.config.jwt.audience }}
             - name: jwt__authority

--- a/charts/project-origin-wallet/templates/migrate-job.yaml
+++ b/charts/project-origin-wallet/templates/migrate-job.yaml
@@ -17,7 +17,7 @@ spec:
           args:
             - "--migrate"
           env:
-          {{ if .Values.persistance.cloudNativePG.enabled }}
+          {{- if eq .Values.persistance.type "CloudNativePG" }}
             - name: DB_HOST
               value: {{ .Values.persistance.cloudNativePG.name }}-rw
             - name: DB_PORT
@@ -36,4 +36,10 @@ spec:
                   key: password
             - name: ConnectionStrings__Database
               value: Host=$(DB_HOST); Port=$(DB_PORT); Database=$(DB_DATABASE); Username=$(DB_USERNAME); Password=$(DB_PASSWORD);
+          {{- else if eq .Values.persistance.type "BYOD" }}
+            - name: ConnectionStrings__Database
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.persistance.byod.secretName }}
+                  key: connectionString
           {{ end }}

--- a/charts/project-origin-wallet/templates/migrate-job.yaml
+++ b/charts/project-origin-wallet/templates/migrate-job.yaml
@@ -17,29 +17,29 @@ spec:
           args:
             - "--migrate"
           env:
-          {{- if eq .Values.persistance.type "CloudNativePG" }}
+          {{- if eq .Values.persistence.type "CloudNativePG" }}
             - name: DB_HOST
-              value: {{ .Values.persistance.cloudNativePG.name }}-rw
+              value: {{ .Values.persistence.cloudNativePG.name }}-rw
             - name: DB_PORT
               value: "5432"
             - name: DB_DATABASE
-              value: {{ .Values.persistance.cloudNativePG.database }}
+              value: {{ .Values.persistence.cloudNativePG.database }}
             - name: DB_USERNAME
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.persistance.cloudNativePG.name }}-app
+                  name: {{ .Values.persistence.cloudNativePG.name }}-app
                   key: username
             - name: DB_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.persistance.cloudNativePG.name }}-app
+                  name: {{ .Values.persistence.cloudNativePG.name }}-app
                   key: password
             - name: ConnectionStrings__Database
               value: Host=$(DB_HOST); Port=$(DB_PORT); Database=$(DB_DATABASE); Username=$(DB_USERNAME); Password=$(DB_PASSWORD);
-          {{- else if eq .Values.persistance.type "BYOD" }}
+          {{- else if eq .Values.persistence.type "BYOD" }}
             - name: ConnectionStrings__Database
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.persistance.byod.secretName }}
+                  name: {{ .Values.persistence.byod.secretName }}
                   key: connectionString
           {{ end }}

--- a/charts/project-origin-wallet/templates/migrate-job.yaml
+++ b/charts/project-origin-wallet/templates/migrate-job.yaml
@@ -41,5 +41,5 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.persistence.byod.secretName }}
-                  key: connectionString
+                  key:  {{ .Values.persistence.byod.secretKey }}
           {{ end }}

--- a/charts/project-origin-wallet/values.yaml
+++ b/charts/project-origin-wallet/values.yaml
@@ -97,7 +97,7 @@ registries: []
   #   address: http://test-registry:80
 
 # persistence defines the persistence configuration for the wallet server
-persistance:
+persistence:
 
   # type defines which database to use. "CloudNativePG" for built-in PostgreSQL or "BYOD" (Bring Your Own Database) for using an external PostgreSQL database. Only PostgreSQL is supported.
   type: "CloudNativePG"
@@ -120,6 +120,10 @@ persistance:
     # storage defines the storage configuration for the database
     size: 10Gi
 
-  # Add BYOD configuration
+  # BYOD (Bring Your Own Database) configuration
   byod:
-    secretName: ""  # The user must create a secret with the necessary DB connection information
+
+    # Create a secret with the DB connection info and provide the secret name here
+    secretName: ""
+    # Specify the key within the secret that contains the DB connection string
+    secretKey: ""

--- a/charts/project-origin-wallet/values.yaml
+++ b/charts/project-origin-wallet/values.yaml
@@ -99,9 +99,9 @@ registries: []
 # persistence defines the persistence configuration for the wallet server
 persistance:
 
-  # Choose database type: "CloudNativePG" for built-in PostgreSQL or "BYOD" (Bring Your Own Database) for using an external PostgreSQL database. Only PostgreSQL is supported.
-
+  # type defines which database to use. "CloudNativePG" for built-in PostgreSQL or "BYOD" (Bring Your Own Database) for using an external PostgreSQL database. Only PostgreSQL is supported.
   type: "CloudNativePG"
+
   # cloudNativePG determines if the database is created as a cloud native postgresql instance
   cloudNativePG:
 

--- a/charts/project-origin-wallet/values.yaml
+++ b/charts/project-origin-wallet/values.yaml
@@ -104,7 +104,7 @@ persistance:
 
   # Type of database to use: "CloudNativePG" or "BYOD"
 
-  type: ""
+  type: "CloudNativePG"
   # cloudNativePG determines if the database is created as a cloud native postgresql instance
   cloudNativePG:
 

--- a/charts/project-origin-wallet/values.yaml
+++ b/charts/project-origin-wallet/values.yaml
@@ -99,11 +99,14 @@ registries: []
 # persistence defines the persistence configuration for the wallet server
 persistance:
 
+  # enabled determines if the cloud native postgresql instance is enabled
+  enabled: true
+
+  # Type of database to use: "CloudNativePG" or "BYOD"
+
+  type: ""
   # cloudNativePG determines if the database is created as a cloud native postgresql instance
   cloudNativePG:
-
-    # enabled determines if the cloud native postgresql instance is enabled
-    enabled: true
 
     # name defines the name of the cloud native postgresql instance
     name: cnpg-wallet-db
@@ -119,3 +122,7 @@ persistance:
 
     # storage defines the storage configuration for the database
     size: 10Gi
+
+  # Add BYOD configuration
+  byod:
+    secretName: ""  # The user must create a secret with the necessary DB connection information

--- a/charts/project-origin-wallet/values.yaml
+++ b/charts/project-origin-wallet/values.yaml
@@ -99,10 +99,7 @@ registries: []
 # persistence defines the persistence configuration for the wallet server
 persistance:
 
-  # enabled determines if the cloud native postgresql instance is enabled
-  enabled: true
-
-  # Type of database to use: "CloudNativePG" or "BYOD"
+  # Choose database type: "CloudNativePG" for built-in PostgreSQL or "BYOD" (Bring Your Own Database) for using an external PostgreSQL database. Only PostgreSQL is supported.
 
   type: "CloudNativePG"
   # cloudNativePG determines if the database is created as a cloud native postgresql instance


### PR DESCRIPTION
# Project Origin Wallet Configuration Update

## Database Integration Update:

The persistence configuration now includes a BYOD (Bring Your Own Database) option.

This allows the wallet server to connect with an external PostgreSQL databases.

## Persistence configuration:

New fields, `secretName` and `secretKey`, have been added under the `persistence.byod` configuration. These fields are used to manage database connection details securely:

- `secretName`: This field is used to specify the name of a Kubernetes Secret that contains the database connection string.

- `secretKey`: This field is used to specify the key within the Kubernetes Secret that contains the connection string.

## Breaking Changes:

### Variable name change

The variable `persistance` has been renamed to `persistence` to align with the correct spelling.

This change affects the configuration settings for the database in the Project Origin Wallet server.

To ensure seamless operation and compatibility with the latest version, users will need to update their configurations to use the correct `persistence` spelling.

### Required actions

- Users should review their deployment configurations, scripts, and any related documentation.

- Any instance of `persistance` should be updated to `persistence`, in your manifests, to match the corrected spelling.

- We recommend testing the updated configurations in a development or staging environment before rolling out to production.