### PR TITLE
align helm chart with code

### DIFF
--- a/charts/project-origin-wallet/values.yaml
+++ b/charts/project-origin-wallet/values.yaml
@@ -33,7 +33,7 @@ config:
 
     # disables the jwt authentication, and sets the subject of the call from a header. This requires authentication and authorization to be done by another system.
     header:
-      headerName:
+      headerName: ""
 
     # jwt defines the configuration for the authentication of jwt tokens
     jwt:

--- a/charts/project-origin-wallet/values.yaml
+++ b/charts/project-origin-wallet/values.yaml
@@ -33,7 +33,7 @@ config:
 
     # disables the jwt authentication, and sets the subject of the call from a header. This requires authentication and authorization to be done by another system.
     header:
-      name:
+      headerName:
 
     # jwt defines the configuration for the authentication of jwt tokens
     jwt:


### PR DESCRIPTION
Problem is that currently helm chart is like: 

```
    header:
      name:
```

but code has 20+ refferences to 

```
serverFixture.ConfigureHostConfiguration(new()
        {
            {"auth:type", "header"},
            {"auth:header:headerName", HeaderName}
        });
    }
```

So it would make sense to change it to:
```

    header:
      headerName:
```