### PR TITLE
bug: Added extra guard for reserving slice

### DIFF
--- a/src/ProjectOrigin.WalletSystem.Server/Repositories/CertificateRepository.cs
+++ b/src/ProjectOrigin.WalletSystem.Server/Repositories/CertificateRepository.cs
@@ -437,7 +437,20 @@ public class CertificateRepository : ICertificateRepository
 
         foreach (var slice in takenSlices)
         {
-            await SetWalletSliceState(slice.Id, WalletSliceState.Reserved);
+            var rowsChanged = await _connection.ExecuteAsync(
+                @"UPDATE wallet_slices
+                SET state = @state
+                WHERE id = @sliceId
+                    AND state = @expected",
+                new
+                {
+                    sliceid = slice.Id,
+                    state = WalletSliceState.Reserved,
+                    expected = WalletSliceState.Available
+                });
+
+            if (rowsChanged != 1)
+                throw new InvalidOperationException($"Slice with id {slice.Id} could not be found or was no longer available");
         }
 
         return takenSlices;


### PR DESCRIPTION
This commit updates the `CertificateRepository` by changing the logic for setting the state of wallet slices. Instead of using the `SetWalletSliceState` method, it now directly executes an SQL query to update the `state` column in the `wallet_slices` table. The new query sets the state to `WalletSliceState.Reserved` only if the current state is `WalletSliceState.Available`. If the number of rows changed by the query is not equal to 1, an `InvalidOperationException` is thrown with a corresponding error message.

This change should insure extra  guard against double reserving the same slice.