### PR TITLE
ClaimCertificateCommandHandler correctly handles transient exceptions

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
 // README at: https://github.com/devcontainers/templates/tree/main/src/dotnet
 {
     "name": "C# (.NET)",
-    "image": "mcr.microsoft.com/devcontainers/dotnet:1.2.1-8.0-jammy",
+    "image": "mcr.microsoft.com/devcontainers/dotnet:1.3.0-8.0-jammy",
     // Features to add to the dev container. More info: https://containers.dev/features.
     "features": {
         "ghcr.io/devcontainers/features/docker-in-docker:2": {},

--- a/src/ProjectOrigin.WalletSystem.IntegrationTests/CommandHandlers/ClaimCertificatesCommandHandlerTests.cs
+++ b/src/ProjectOrigin.WalletSystem.IntegrationTests/CommandHandlers/ClaimCertificatesCommandHandlerTests.cs
@@ -7,7 +7,10 @@ using FluentAssertions;
 using MassTransit;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using NSubstitute.ReceivedExtensions;
 using ProjectOrigin.WalletSystem.Server;
+using ProjectOrigin.WalletSystem.Server.Activities.Exceptions;
 using ProjectOrigin.WalletSystem.Server.CommandHandlers;
 using ProjectOrigin.WalletSystem.Server.Database;
 using ProjectOrigin.WalletSystem.Server.Models;
@@ -58,6 +61,35 @@ public class ClaimCertificatesCommandHandlerTests
         await _processBuilder.Received(1).Claim(Arg.Is(prodSlices.Single()), Arg.Is(consSlices.Single()));
         _processBuilder.Received(1).Build();
         _processBuilder.ReceivedCalls().Count().Should().Be(2);
+    }
+
+    [Fact]
+    public async Task ReserveQuantityThrowsTransientException_TransientException()
+    {
+        // arrange
+        var command = new ClaimCertificateCommand
+        {
+            Owner = _owner,
+            ClaimId = Guid.NewGuid(),
+            ConsumptionRegistry = _registryName,
+            ConsumptionCertificateId = Guid.NewGuid(),
+            ProductionRegistry = _registryName,
+            ProductionCertificateId = Guid.NewGuid(),
+            Quantity = 123
+        };
+        _context.Message.Returns(command);
+        _unitOfWork.CertificateRepository.ReserveQuantity(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<Guid>(),
+            Arg.Any<uint>())
+            .ThrowsAsync(_ => throw new TransientException("Failed to handle claim at this time. Retrying."));
+
+        // act
+        var sut = () => _commandHandler.Consume(_context);
+
+        // assert
+        await sut.Should().ThrowAsync<TransientException>();
     }
 
     [Fact]

--- a/src/ProjectOrigin.WalletSystem.IntegrationTests/CommandHandlers/ClaimCertificatesCommandHandlerTests.cs
+++ b/src/ProjectOrigin.WalletSystem.IntegrationTests/CommandHandlers/ClaimCertificatesCommandHandlerTests.cs
@@ -83,7 +83,7 @@ public class ClaimCertificatesCommandHandlerTests
             Arg.Any<string>(),
             Arg.Any<Guid>(),
             Arg.Any<uint>())
-            .ThrowsAsync(_ => throw new TransientException("Failed to handle claim at this time. Retrying."));
+            .ThrowsAsync(_ => throw new TransientException("Failed to handle claim at this time."));
 
         // act
         var sut = () => _commandHandler.Consume(_context);

--- a/src/ProjectOrigin.WalletSystem.Server/CommandHandlers/ClaimCertificateCommandHandler.cs
+++ b/src/ProjectOrigin.WalletSystem.Server/CommandHandlers/ClaimCertificateCommandHandler.cs
@@ -66,7 +66,7 @@ public class ClaimCertificateCommandHandler : IConsumer<ClaimCertificateCommand>
         catch (TransientException ex)
         {
             _unitOfWork.Rollback();
-            _logger.LogWarning(ex, "Failed to handle claim at this time. Retrying.");
+            _logger.LogWarning(ex, "Failed to handle claim at this time.");
             throw;
         }
         catch (Exception ex)

--- a/src/ProjectOrigin.WalletSystem.Server/CommandHandlers/ClaimCertificateCommandHandler.cs
+++ b/src/ProjectOrigin.WalletSystem.Server/CommandHandlers/ClaimCertificateCommandHandler.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using MassTransit;
 using MassTransit.Courier.Contracts;
 using Microsoft.Extensions.Logging;
+using ProjectOrigin.WalletSystem.Server.Activities.Exceptions;
 using ProjectOrigin.WalletSystem.Server.Database;
 using ProjectOrigin.WalletSystem.Server.Extensions;
 using ProjectOrigin.WalletSystem.Server.Models;
@@ -61,6 +62,12 @@ public class ClaimCertificateCommandHandler : IConsumer<ClaimCertificateCommand>
         {
             _unitOfWork.Rollback();
             _logger.LogWarning(ex, "Claim is not allowed.");
+        }
+        catch (TransientException ex)
+        {
+            _unitOfWork.Rollback();
+            _logger.LogWarning(ex, "Failed to handle claim at this time. Retrying.");
+            throw;
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
… so that they are retried. 