### PR TITLE
Add resource-policy annotations to rabbitmq and cloudnativepg resources

### DIFF
--- a/charts/project-origin-wallet/templates/cnpg-cluster.yaml
+++ b/charts/project-origin-wallet/templates/cnpg-cluster.yaml
@@ -5,6 +5,8 @@ kind: Cluster
 metadata:
   name: {{ .Values.persistence.cloudNativePG.name }}
   namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/resource-policy": keep
 spec:
   instances: {{ .Values.persistence.cloudNativePG.replicas }}
   storage:

--- a/charts/project-origin-wallet/templates/rabbitmq.yaml
+++ b/charts/project-origin-wallet/templates/rabbitmq.yaml
@@ -4,4 +4,6 @@ kind: RabbitmqCluster
 metadata:
   name: {{ .Release.Name }}-rabbitmq
   namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/resource-policy": keep
 {{- end }}


### PR DESCRIPTION
These annotations are done to ensure that rabbitmq and cloudnative PG is not delete when next release will come, where these resources are no longer a part of the chart.