### PR TITLE
Refactor deployment.yaml to quote rabbitmq.replicas value when quorum enabled

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -77,7 +77,7 @@ spec:
               value: {{ $.Values.rabbitmq.quorum | quote}}
             {{- if $.Values.rabbitmq.quorum }}
             - name: MessageBroker__RabbitMQ__Replicas
-              value: {{ required "rabbitmq.replicas must be set when quorum enabled" $.Values.rabbitmq.replicas }}
+              value: {{ required "rabbitmq.replicas must be set when quorum enabled" $.Values.rabbitmq.replicas | quote }}
             {{- end }}
 
           # Authentication


### PR DESCRIPTION
This pull request refactors the deployment.yaml file to ensure that the rabbitmq.replicas value is quoted when quorum is enabled. This change ensures that the value is correctly interpreted and avoids any potential issues with the deployment.