### PR TITLE
Remove storage from defaults.

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -263,8 +263,6 @@ migrationWaiter:
       cpu:
       # memory defines the memory limit for the registry server
       memory: 50Mi
-      # ephemeralStorage defines the ephemeral storage limit for the verifier server
-      ephemeralStorage: 100Mi
 
 # retry holds the configuration for retry logic
 retry:


### PR DESCRIPTION
Pods are dying left and right: "Pod ephemeral local storage usage exceeds the total limit of containers 100Mi.".
Seems that when under huge load, the standard out logging is starting to take up space from the storage, there for killing the pods.