### PR TITLE
Does not requeue reserve errors

### DIFF
--- a/src/ProjectOrigin.Vault/CommandHandlers/ClaimCertificateCommandHandler.cs
+++ b/src/ProjectOrigin.Vault/CommandHandlers/ClaimCertificateCommandHandler.cs
@@ -67,7 +67,7 @@ public class ClaimCertificateCommandHandler : IConsumer<ClaimCertificateCommand>
         {
             _unitOfWork.Rollback();
             _logger.LogWarning(ex, "Failed to handle claim at this time.");
-            await context.Publish(context.Message);
+            throw;
         }
         catch (Exception ex)
         {

--- a/src/ProjectOrigin.Vault/CommandHandlers/TransferCertificateCommandHandler.cs
+++ b/src/ProjectOrigin.Vault/CommandHandlers/TransferCertificateCommandHandler.cs
@@ -101,7 +101,7 @@ public class TransferCertificateCommandHandler : IConsumer<TransferCertificateCo
         {
             _unitOfWork.Rollback();
             _logger.LogWarning(ex, "Failed to handle transfer at this time.");
-            await context.Publish(context.Message);
+            throw;
         }
         catch (Exception ex)
         {

--- a/src/ProjectOrigin.Vault/Startup.cs
+++ b/src/ProjectOrigin.Vault/Startup.cs
@@ -92,7 +92,11 @@ public class Startup
                 });
             }
 
-            o.AddConsumer<TransferCertificateCommandHandler>();
+            o.AddConsumer<TransferCertificateCommandHandler>(cfg =>
+            {
+                cfg.UseMessageRetry(r => r.Interval(10, TimeSpan.FromSeconds(15))
+                    .Handle<QuantityNotYetAvailableToReserveException>());
+            });
 
             o.AddConsumer<VerifySliceCommandHandler>(cfg =>
             {
@@ -100,7 +104,11 @@ public class Startup
                     .Handle<TransientException>());
             });
 
-            o.AddConsumer<ClaimCertificateCommandHandler>();
+            o.AddConsumer<ClaimCertificateCommandHandler>(cfg =>
+            {
+                cfg.UseMessageRetry(r => r.Interval(10, TimeSpan.FromSeconds(15))
+                    .Handle<QuantityNotYetAvailableToReserveException>());
+            });
 
             o.AddConsumer<CheckForWithdrawnCertificatesCommandHandler>();
 

--- a/test/ProjectOrigin.Vault.Tests/CommandHandlers/ClaimCertificatesCommandHandlerTests.cs
+++ b/test/ProjectOrigin.Vault.Tests/CommandHandlers/ClaimCertificatesCommandHandlerTests.cs
@@ -62,7 +62,7 @@ public class ClaimCertificatesCommandHandlerTests
     }
 
     [Fact]
-    public async Task ReserveQuantityThrowsQuantityNotYetAvailableToReserveException_Requeue()
+    public async Task ReserveQuantityThrowsQuantityNotYetAvailableToReserveException_Throws()
     {
         // arrange
         var command = new ClaimCertificateCommand
@@ -84,9 +84,9 @@ public class ClaimCertificatesCommandHandlerTests
             .ThrowsAsync(_ => throw new QuantityNotYetAvailableToReserveException("Owner has enough quantity, but it is not yet available to reserve"));
 
         // act
-        await _commandHandler.Consume(_context);
+        var sut = () => _commandHandler.Consume(_context);
 
-        await _context.Received(1).Publish(Arg.Any<ClaimCertificateCommand>());
+        await sut.Should().ThrowAsync<QuantityNotYetAvailableToReserveException>();
     }
 
     [Fact]

--- a/test/ProjectOrigin.Vault.Tests/CommandHandlers/TransferCertificateCommandHandlerTests.cs
+++ b/test/ProjectOrigin.Vault.Tests/CommandHandlers/TransferCertificateCommandHandlerTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using AutoFixture;
+using FluentAssertions;
 using MassTransit;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
@@ -38,7 +39,7 @@ public class TransferCertificateCommandHandlerTests
     }
 
     [Fact]
-    public async Task ReserveQuantityThrowsQuantityNotYetAvailableToReserveException_Requeue()
+    public async Task ReserveQuantityThrowsQuantityNotYetAvailableToReserveException_Throws()
     {
         var command = new TransferCertificateCommand
         {
@@ -60,8 +61,8 @@ public class TransferCertificateCommandHandlerTests
                 Arg.Any<uint>())
             .ThrowsAsync(_ => throw new QuantityNotYetAvailableToReserveException("Owner has enough quantity, but it is not yet available to reserve"));
 
-        await _commandHandler.Consume(_context);
+        var sut = () => _commandHandler.Consume(_context);
 
-        await _context.Received(1).Publish(Arg.Any<TransferCertificateCommand>());
+        await sut.Should().ThrowAsync<QuantityNotYetAvailableToReserveException>();
     }
 }


### PR DESCRIPTION
Requeue as agressively as we did causes performance issues. With the new approach to finalization, it's no longer needed to requeue and we can keep the messages in front of the queue