### PR TITLE
Fix SendClaimIntentToChroniclerActivity to use new argument structure

### DIFF
--- a/src/ProjectOrigin.Vault/RegistryProcessBuilder/Claim.cs
+++ b/src/ProjectOrigin.Vault/RegistryProcessBuilder/Claim.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Threading.Tasks;
-using Google.Protobuf;
-using ProjectOrigin.Chronicler.V1;
 using ProjectOrigin.Common.V1;
 using ProjectOrigin.Electricity.V1;
 using ProjectOrigin.Vault.Activities;
@@ -95,13 +93,10 @@ public partial class RegistryProcessBuilder
             chroniclerRequestId = Guid.NewGuid();
             AddActivity<SendClaimIntentToChroniclerActivity, SendClaimIntentToChroniclerArgument>(new SendClaimIntentToChroniclerArgument
             {
-                ClaimIntentRequest = new ClaimIntentRequest
-                {
-                    CertificateId = slice.GetFederatedStreamId(),
-                    Quantity = (int)slice.Quantity,
-                    RandomR = ByteString.CopyFrom(slice.RandomR)
-                },
-                Id = chroniclerRequestId.Value
+                Id = chroniclerRequestId.Value,
+                CertificateId = slice.GetFederatedStreamId(),
+                Quantity = (int)slice.Quantity,
+                RandomR = slice.RandomR
             });
         }
 

--- a/test/ProjectOrigin.Vault.Tests/ActivityTests/SendClaimIntentToChroniclerActivityTests.cs
+++ b/test/ProjectOrigin.Vault.Tests/ActivityTests/SendClaimIntentToChroniclerActivityTests.cs
@@ -45,19 +45,16 @@ namespace ProjectOrigin.Vault.Tests.ActivityTests
             var arguments = new SendClaimIntentToChroniclerArgument
             {
                 Id = System.Guid.NewGuid(),
-                ClaimIntentRequest = new ClaimIntentRequest()
+                CertificateId = new FederatedStreamId()
                 {
-                    CertificateId = new FederatedStreamId()
+                    Registry = registryName,
+                    StreamId = new Uuid
                     {
-                        Registry = registryName,
-                        StreamId = new Uuid
-                        {
-                            Value = System.Guid.NewGuid().ToString()
-                        }
-                    },
-                    Quantity = 1,
-                    RandomR = ByteString.CopyFrom(fixture.Create<byte[]>()),
-                }
+                        Value = System.Guid.NewGuid().ToString()
+                    }
+                },
+                Quantity = 1,
+                RandomR = fixture.Create<byte[]>(),
             };
 
             var returnValue = Mock.Of<ExecutionResult>();
@@ -99,19 +96,16 @@ namespace ProjectOrigin.Vault.Tests.ActivityTests
             var arguments = new SendClaimIntentToChroniclerArgument
             {
                 Id = System.Guid.NewGuid(),
-                ClaimIntentRequest = new ClaimIntentRequest()
+                CertificateId = new FederatedStreamId()
                 {
-                    CertificateId = new FederatedStreamId()
+                    Registry = registryName,
+                    StreamId = new Uuid
                     {
-                        Registry = registryName,
-                        StreamId = new Uuid
-                        {
-                            Value = System.Guid.NewGuid().ToString()
-                        }
-                    },
-                    Quantity = 1,
-                    RandomR = ByteString.CopyFrom(new byte[] { 1, 2, 3 }),
-                }
+                        Value = System.Guid.NewGuid().ToString()
+                    }
+                },
+                Quantity = 1,
+                RandomR = new byte[] { 1, 2, 3 },
             };
 
             var context = new Mock<ExecuteContext<SendClaimIntentToChroniclerArgument>>(MockBehavior.Strict);

--- a/test/ProjectOrigin.Vault.Tests/CommandHandlers/TransferCertificateCommandHandlerTests.cs
+++ b/test/ProjectOrigin.Vault.Tests/CommandHandlers/TransferCertificateCommandHandlerTests.cs
@@ -53,7 +53,7 @@ public class TransferCertificateCommandHandlerTests
         };
         _context.Message.Returns(command);
         _unitOfWork.WalletRepository.GetExternalEndpoint(Arg.Any<Guid>())
-            .Returns(new ExternalEndpoint { Endpoint = "http://localhost:5000", Id = Guid.NewGuid(), Owner = _owner, ReferenceText = "", PublicKey = null });
+            .Returns(new ExternalEndpoint { Endpoint = "http://localhost:5000", Id = Guid.NewGuid(), Owner = _owner, ReferenceText = "", PublicKey = null! });
         _unitOfWork.CertificateRepository.ReserveQuantity(
                 Arg.Any<string>(),
                 Arg.Any<string>(),

--- a/test/ProjectOrigin.Vault.Tests/ExpireTests.cs
+++ b/test/ProjectOrigin.Vault.Tests/ExpireTests.cs
@@ -65,7 +65,7 @@ public class ExpireTests
         var content = JsonConvert.DeserializeObject<ResultList<GranularCertificate, PageInfo>>(await res.Content.ReadAsStringAsync());
 
         content.Should().NotBeNull();
-        content.Result.Count().Should().Be(1);
+        content!.Result.Count().Should().Be(1);
         content.Result.First().FederatedStreamId.StreamId.Should().Be(certId);
     }
 }

--- a/test/ProjectOrigin.Vault.Tests/JobTests/ExpireCertificatesJobTests.cs
+++ b/test/ProjectOrigin.Vault.Tests/JobTests/ExpireCertificatesJobTests.cs
@@ -55,7 +55,7 @@ public class ExpireCertificatesJobTests
         var content = JsonConvert.DeserializeObject<ResultList<GranularCertificate, PageInfo>>(await res.Content.ReadAsStringAsync());
 
         content.Should().NotBeNull();
-        content.Result.Count().Should().Be(1);
+        content!.Result.Count().Should().Be(1);
         content.Result.First().FederatedStreamId.StreamId.Should().Be(certToExpireId);
     }
 }

--- a/test/ProjectOrigin.Vault.Tests/RegistryProcessBuilder/ClaimTests.cs
+++ b/test/ProjectOrigin.Vault.Tests/RegistryProcessBuilder/ClaimTests.cs
@@ -187,10 +187,10 @@ public class ClaimTests : IClassFixture<PostgresDatabaseFixture>
         slip.Itinerary[0].ShouldBeActivity<SendClaimIntentToChroniclerActivity, SendClaimIntentToChroniclerArgument>()
             .Should().Match<SendClaimIntentToChroniclerArgument>(x =>
                 x.Id != Guid.Empty &&
-                x.ClaimIntentRequest.CertificateId.Registry == prodCert.RegistryName &&
-                x.ClaimIntentRequest.CertificateId.StreamId.Value == prodCert.Id.ToString() &&
-                x.ClaimIntentRequest.Quantity == prodSlice.Quantity &&
-                x.ClaimIntentRequest.RandomR.ToArray().SequenceEqual(prodSlice.RandomR));
+                x.CertificateId.Registry == prodCert.RegistryName &&
+                x.CertificateId.StreamId.Value == prodCert.Id.ToString() &&
+                x.Quantity == prodSlice.Quantity &&
+                x.RandomR.ToArray().SequenceEqual(prodSlice.RandomR));
         var chronId = slip.Itinerary[0].ShouldBeActivity<SendClaimIntentToChroniclerActivity, SendClaimIntentToChroniclerArgument>().Id;
 
         slip.Itinerary[1].ShouldBeActivity<AllocateActivity, AllocateArguments>()
@@ -210,10 +210,10 @@ public class ClaimTests : IClassFixture<PostgresDatabaseFixture>
         slip.Itinerary[2].ShouldBeActivity<SendClaimIntentToChroniclerActivity, SendClaimIntentToChroniclerArgument>()
             .Should().Match<SendClaimIntentToChroniclerArgument>(x =>
                 x.Id != Guid.Empty &&
-                x.ClaimIntentRequest.CertificateId.Registry == consCert.RegistryName &&
-                x.ClaimIntentRequest.CertificateId.StreamId.Value == consCert.Id.ToString() &&
-                x.ClaimIntentRequest.Quantity == consSlice.Quantity &&
-                x.ClaimIntentRequest.RandomR.ToArray().SequenceEqual(consSlice.RandomR));
+                x.CertificateId.Registry == consCert.RegistryName &&
+                x.CertificateId.StreamId.Value == consCert.Id.ToString() &&
+                x.Quantity == consSlice.Quantity &&
+                x.RandomR.ToArray().SequenceEqual(consSlice.RandomR));
         var chronId2 = slip.Itinerary[2].ShouldBeActivity<SendClaimIntentToChroniclerActivity, SendClaimIntentToChroniclerArgument>().Id;
 
         slip.Itinerary[3].ShouldBeActivity<AllocateActivity, AllocateArguments>()


### PR DESCRIPTION
Fix activity, since protobuf.bytestring could not be serialized by masstransit.