### PR TITLE
Only enable specific routing slip events

### DIFF
--- a/src/ProjectOrigin.Vault/Extensions/IItineraryBuilderExtensions.cs
+++ b/src/ProjectOrigin.Vault/Extensions/IItineraryBuilderExtensions.cs
@@ -13,11 +13,11 @@ public static class IItineraryBuilderExtensions
     {
         var uri = new Uri($"exchange:{formatter.ExecuteActivity<T, TArguments>()}");
 
+        builder.AddActivity(typeof(T).Name, uri, arguments);
+
         builder.AddSubscription(
             uri,
             RoutingSlipEvents.Faulted | RoutingSlipEvents.ActivityCompensationFailed |
             RoutingSlipEvents.ActivityFaulted | RoutingSlipEvents.CompensationFailed);
-
-        builder.AddActivity(typeof(T).Name, uri, arguments);
     }
 }

--- a/src/ProjectOrigin.Vault/Extensions/IItineraryBuilderExtensions.cs
+++ b/src/ProjectOrigin.Vault/Extensions/IItineraryBuilderExtensions.cs
@@ -1,15 +1,23 @@
 using System;
 using MassTransit;
+using MassTransit.Courier.Contracts;
 
 namespace ProjectOrigin.Vault.Extensions;
 
 public static class IItineraryBuilderExtensions
 {
-    public static void AddActivity<T, TArguments>(this IItineraryBuilder builder, IEndpointNameFormatter formatter, TArguments arguments)
+    public static void AddActivity<T, TArguments>(this IItineraryBuilder builder, IEndpointNameFormatter formatter,
+        TArguments arguments)
         where T : class, IExecuteActivity<TArguments>
         where TArguments : class
     {
         var uri = new Uri($"exchange:{formatter.ExecuteActivity<T, TArguments>()}");
+
+        builder.AddSubscription(
+            uri,
+            RoutingSlipEvents.Faulted | RoutingSlipEvents.ActivityCompensationFailed |
+            RoutingSlipEvents.ActivityFaulted | RoutingSlipEvents.CompensationFailed);
+
         builder.AddActivity(typeof(T).Name, uri, arguments);
     }
 }

--- a/src/ProjectOrigin.Vault/RegistryProcessBuilder/Base.cs
+++ b/src/ProjectOrigin.Vault/RegistryProcessBuilder/Base.cs
@@ -38,6 +38,7 @@ public partial class RegistryProcessBuilder : IRegistryProcessBuilder
     {
         var uri = new Uri($"exchange:{_formatter.ExecuteActivity<T, TArguments>()}");
         _slipBuilder.AddActivity(typeof(T).Name, uri, arguments);
+
         _slipBuilder.AddSubscription(
             uri,
             RoutingSlipEvents.Faulted | RoutingSlipEvents.ActivityCompensationFailed |


### PR DESCRIPTION
- To minimize the amount of routing slip events and avoid a lot of unroutable messages from events, we only keep the faulted events
- <https://masstransit.io/documentation/concepts/routing-slips#subscriptions>

Unroutable events for the preview enrivonment
https://routingslipevents.p.acorn-dev.dk/admin/thanos/graph?g0.expr=rabbitmq_exchange_messages_unroutable_dropped_total&g0.tab=0&g0.stacked=0&g0.range_input=1d&g0.max_source_resolution=0s&g0.deduplicate=1&g0.partial_response=1&g0.store_matches=%5B%5D&g0.engine=prometheus&g0.analyze=0&g0.tenant=
![image](https://github.com/user-attachments/assets/fefbca1f-04de-4c47-9a24-e4db5de590f5)

Compared to another preview environment
https://restrictaccessimds.p.acorn-dev.dk/admin/thanos/graph?g0.expr=rabbitmq_exchange_messages_unroutable_dropped_total&g0.tab=0&g0.stacked=0&g0.range_input=1d&g0.max_source_resolution=0s&g0.deduplicate=1&g0.partial_response=1&g0.store_matches=%5B%5D&g0.engine=prometheus&g0.analyze=0&g0.tenant=
![image](https://github.com/user-attachments/assets/7311dc9d-7c88-4ab6-b1f2-03baa5bf9bca)