### PR TITLE
Optimize vault queries

### DIFF
--- a/src/ProjectOrigin.Vault/Database/Postgres/Scripts/v2/v2-0016.sql
+++ b/src/ProjectOrigin.Vault/Database/Postgres/Scripts/v2/v2-0016.sql
@@ -1,0 +1,4 @@
+-- Used to optimize queries where we need available wallet slices that have a positive quantity
+CREATE INDEX IF NOT EXISTS idx_wallet_slices_filtered
+ON wallet_slices(wallet_endpoint_id)
+WHERE state = 1 AND quantity != 0;


### PR DESCRIPTION
- Optimized QueryAvailableCertificates
  - Inlined `certificates_query_model` in the query.
    - This allows us to filter before before joins and aggregations (using available_slices and non_withdrawn_certificates). I.e. we have fewer rows to join
    - We can also remove the CASE inside the aggregation to get a faster aggregation (the logic is moved to available_slices)
- Added index to optimize queries that need available wallet slices that have a positive quantity



## Before optimization
![image](https://github.com/user-attachments/assets/be362faf-caa0-45e7-85e4-af8614ba968d)
![image](https://github.com/user-attachments/assets/e435d11c-6a0b-4b40-bf36-e6ed80ed2f4b)

## After optimization
![image](https://github.com/user-attachments/assets/e62cd296-7edf-4a29-bf8d-9d5410ca92b0)
![image](https://github.com/user-attachments/assets/6a35cae1-1f8b-465b-8f9d-24617e1f64dd)